### PR TITLE
Allow arbitrary-length passwords via the CLI

### DIFF
--- a/src/bin/pg_dump/pg_backup_db.c
+++ b/src/bin/pg_dump/pg_backup_db.c
@@ -143,7 +143,7 @@ _connectDB(ArchiveHandle *AH, const char *reqdb, const char *requser)
 
 	if (AH->promptPassword == TRI_YES && password == NULL)
 	{
-		password = simple_prompt("Password: ", 100, false);
+		password = simple_prompt("Password: ", MAX_PASSWD, false);
 		if (password == NULL)
 			die_horribly(AH, modulename, "out of memory\n");
 	}
@@ -195,7 +195,7 @@ _connectDB(ArchiveHandle *AH, const char *reqdb, const char *requser)
 				free(password);
 
 			if (AH->promptPassword != TRI_NO)
-				password = simple_prompt("Password: ", 100, false);
+				password = simple_prompt("Password: ", MAX_PASSWD, false);
 			else
 				die_horribly(AH, modulename, "connection needs password\n");
 
@@ -242,7 +242,7 @@ ConnectDatabase(Archive *AHX,
 
 	if (prompt_password == TRI_YES && password == NULL)
 	{
-		password = simple_prompt("Password: ", 100, false);
+		password = simple_prompt("Password: ", MAX_PASSWD, false);
 		if (password == NULL)
 			die_horribly(AH, modulename, "out of memory\n");
 	}
@@ -288,7 +288,7 @@ ConnectDatabase(Archive *AHX,
 			prompt_password != TRI_NO)
 		{
 			PQfinish(AH->connection);
-			password = simple_prompt("Password: ", 100, false);
+			password = simple_prompt("Password: ", MAX_PASSWD, false);
 			if (password == NULL)
 				die_horribly(AH, modulename, "out of memory\n");
 			new_pass = true;

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -1687,7 +1687,7 @@ connectDatabase(const char *dbname, const char *pghost, const char *pgport,
 	static char *password = NULL;
 
 	if (prompt_password == TRI_YES && !password)
-		password = simple_prompt("Password: ", 100, false);
+		password = simple_prompt("Password: ", MAX_PASSWD, false);
 
 	/*
 	 * Start the connection.  Loop until we have a password if requested by
@@ -1733,7 +1733,7 @@ connectDatabase(const char *dbname, const char *pghost, const char *pgport,
 			prompt_password != TRI_NO)
 		{
 			PQfinish(conn);
-			password = simple_prompt("Password: ", 100, false);
+			password = simple_prompt("Password: ", MAX_PASSWD, false);
 			new_pass = true;
 		}
 	} while (new_pass);

--- a/src/bin/psql/command.c
+++ b/src/bin/psql/command.c
@@ -895,8 +895,8 @@ exec_command(const char *cmd,
 		char	   *pw1;
 		char	   *pw2;
 
-		pw1 = simple_prompt("Enter new password: ", 100, false);
-		pw2 = simple_prompt("Enter it again: ", 100, false);
+		pw1 = simple_prompt("Enter new password: ", MAX_PASSWD, false);
+		pw2 = simple_prompt("Enter it again: ", MAX_PASSWD, false);
 
 		if (strcmp(pw1, pw2) != 0)
 		{
@@ -1462,7 +1462,7 @@ prompt_for_password(const char *username)
 	char	   *result;
 
 	if (username == NULL)
-		result = simple_prompt("Password: ", 100, false);
+		result = simple_prompt("Password: ", MAX_PASSWD, false);
 	else
 	{
 		char	   *prompt_text;
@@ -1470,7 +1470,7 @@ prompt_for_password(const char *username)
 		prompt_text = malloc(strlen(username) + 100);
 		snprintf(prompt_text, strlen(username) + 100,
 				 _("Password for user %s: "), username);
-		result = simple_prompt(prompt_text, 100, false);
+		result = simple_prompt(prompt_text, MAX_PASSWD, false);
 		free(prompt_text);
 	}
 

--- a/src/bin/psql/startup.c
+++ b/src/bin/psql/startup.c
@@ -174,7 +174,7 @@ main(int argc, char *argv[])
 	}
 
 	if (pset.getPassword == TRI_YES)
-		password = simple_prompt(password_prompt, 100, false);
+		password = simple_prompt(password_prompt, MAX_PASSWD, false);
 
 	/* loop until we have a password if requested by backend */
 	do
@@ -213,7 +213,7 @@ main(int argc, char *argv[])
 			pset.getPassword != TRI_NO)
 		{
 			PQfinish(pset.db);
-			password = simple_prompt(password_prompt, 100, false);
+			password = simple_prompt(password_prompt, MAX_PASSWD, false);
 			new_pass = true;
 		}
 	} while (new_pass);

--- a/src/bin/scripts/common.c
+++ b/src/bin/scripts/common.c
@@ -100,7 +100,7 @@ connectDatabase(const char *dbname, const char *pghost, const char *pgport,
 	bool		new_pass;
 
 	if (prompt_password == TRI_YES)
-		password = simple_prompt("Password: ", 100, false);
+		password = simple_prompt("Password: ", MAX_PASSWD, false);
 
 	/*
 	 * Start the connection.  Loop until we have a password if requested by
@@ -152,7 +152,7 @@ connectDatabase(const char *dbname, const char *pghost, const char *pgport,
 			prompt_password != TRI_NO)
 		{
 			PQfinish(conn);
-			password = simple_prompt("Password: ", 100, false);
+			password = simple_prompt("Password: ", MAX_PASSWD, false);
 			new_pass = true;
 		}
 	} while (new_pass);

--- a/src/bin/scripts/createuser.c
+++ b/src/bin/scripts/createuser.c
@@ -197,8 +197,8 @@ main(int argc, char *argv[])
 		char	   *pw1,
 				   *pw2;
 
-		pw1 = simple_prompt("Enter password for new role: ", 100, false);
-		pw2 = simple_prompt("Enter it again: ", 100, false);
+		pw1 = simple_prompt("Enter password for new role: ", MAX_PASSWD, false);
+		pw2 = simple_prompt("Enter it again: ", MAX_PASSWD, false);
 		if (strcmp(pw1, pw2) != 0)
 		{
 			fprintf(stderr, _("Passwords didn't match.\n"));

--- a/src/include/pg_config_manual.h
+++ b/src/include/pg_config_manual.h
@@ -23,6 +23,20 @@
 #define NAMEDATALEN 64
 
 /*
+ * Maximum password length via command line tools
+ *
+ * If 0, no maximum password length is enforced.
+ * If greater than 0, this defines the maximum number of characters
+ * which will be read as input for a password prompt.  Input in
+ * excess of this maximum will be silently ignored.
+ *
+ * The database itself does not have a password length limit,
+ * regardless of this setting.
+ *
+ */
+#define MAX_PASSWD 0
+
+/*
  * Maximum number of arguments to a function.
  *
  * The minimum value is 8 (GIN indexes use 8-argument support functions).

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -4905,22 +4905,31 @@ PasswordFromFile(char *hostname, char *port, char *dbname, char *username)
 
 	while (!feof(fp) && !ferror(fp))
 	{
-		char	   *t = buf,
+		char	   *t = calloc(1,sizeof(char)),
 				   *ret,
 				   *p1,
 				   *p2;
 		int			len;
 
-		if (fgets(buf, sizeof(buf), fp) == NULL)
-			break;
 
-		len = strlen(buf);
+		do
+		{
+			if ( fgets(buf, LINELEN, fp) == NULL)
+				break;
+			t = realloc(t, strlen(t)+1+strlen(buf));
+			/* Out of memory? */
+			if( !t )
+				return NULL;
+			strcat(t, buf);
+			len = strlen(t);
+		} while (strlen(buf) > 0 && t[len-1] != '\n');
+
 		if (len == 0)
 			continue;
 
 		/* Remove trailing newline */
-		if (buf[len - 1] == '\n')
-			buf[len - 1] = 0;
+		while ( len > 0 && (t[len-1] == '\n' || t[len-1] == '\r'))
+			t[--len] = 0;
 
 		if ((t = pwdfMatchesString(t, hostname)) == NULL ||
 			(t = pwdfMatchesString(t, port)) == NULL ||


### PR DESCRIPTION
This is a patch for BUG #6412

Currently, most of the postgresql command-line utilities are limited to a 100-character password.  When a longer password is given, the extra characters are truncated.  This patch should allow the command line utilities to accept passwords of arbitrary length.  It should be noted that passwords longer than 1000 characters may still be truncated at other points in the code.
