### PR TITLE
Corrected filename typo in win32.mak

### DIFF
--- a/src/interfaces/libpq/win32.mak
+++ b/src/interfaces/libpq/win32.mak
@@ -224,8 +224,8 @@ LINK32_OBJS= \
 	$(LIB32_FLAGS) $(DEF_FLAGS) $(LIB32_OBJS)
 <<
 
-"$(INTDIR)\libpq.res" : "$(INTDIR)" libpq-dist.rc
-	$(RSC) $(RSC_PROJ) libpq-dist.rc
+"$(INTDIR)\libpq.res" : "$(INTDIR)" libpq.rc.in
+	$(RSC) $(RSC_PROJ) libpq.rc.in
 
 
 "$(OUTDIR)\$(OUTFILENAME).dll" : "$(OUTDIR)" "$(INTDIR)\libpq.res"


### PR DESCRIPTION
nmake will not run as exists

issue still exists "unable to find libpqdll.def" in make process
