### PR TITLE
Start Walreceiver completely before shut down it on standby server.

### DIFF
--- a/src/backend/replication/walreceiverfuncs.c
+++ b/src/backend/replication/walreceiverfuncs.c
@@ -272,6 +272,15 @@ RequestXLogStreaming(TimeLineID tli, XLogRecPtr recptr, const char *conninfo,
 		walrcv->receivedTLI = tli;
 		walrcv->latestChunkStart = recptr;
 	}
+	/*
+	 * If it will restart the walreceiver, set the receivedUpto to the starting point,
+	 * so that the process will not read the old data before walreceiver starts.
+	 */
+	else if (launch && recptr < walrcv->receivedUpto)
+	{
+		walrcv->receivedUpto = recptr;
+		walrcv->latestChunkStart = recptr;
+	}
 	walrcv->receiveStart = recptr;
 	walrcv->receiveStartTLI = tli;
 


### PR DESCRIPTION
The walreceiver will be shut down, when read an invalid record in the
WAL streaming from master.And then, we retry from archive/pg_wal again.

After that, we start walreceiver in RequestXLogStreaming(), and read
record from the WAL streaming. But before walreceiver starts, we read
data from file which be streamed over and present in pg_wal by last
time, because of walrcv->receivedUpto > RecPtr and the wal is actually
flush on disk. Now, we read the invalid record again, what the next to
do? Shut down the walreceiver and do it again.

So, we always read the invalid record, starting the walreceiver and make
it down before it starts completely.

This code fix it by set the walrcv->receivedUpto to the starting point,
we can read nothing before the walreceiver starts and streaming.