### PR TITLE
Problem with leak on ssl cert validation

### DIFF
--- a/src/interfaces/libpq/fe-secure-openssl.c
+++ b/src/interfaces/libpq/fe-secure-openssl.c
@@ -552,7 +552,7 @@ pgtls_verify_peer_name_matches_certificate_guts(PGconn *conn,
 			if (rc != 0)
 				break;
 		}
-		sk_GENERAL_NAME_free(peer_san);
+		sk_GENERAL_NAME_pop_free(peer_san, GENERAL_NAME_free);
 	}
 
 	/*


### PR DESCRIPTION
Difference described there:
https://www.openssl.org/docs/man1.1.1/man3/sk_TYPE_num.html

sk_TYPE_free() frees up the sk structure. It does not free up any elements of sk. After this call sk is no longer valid.
sk_TYPE_pop_free() frees up all elements of sk and sk itself. The free function freefunc() is called on each element to free it.

With frequent new connections with "verify-full" got leak, which wasn't caught by valgrind, but I've seen increasing memory for this method on Gperftools Heap Profiler.

This fix removed such problem for me.