### PR TITLE
Mentioning High level Categories to Backup Types

### DIFF
--- a/doc/src/sgml/backup.sgml
+++ b/doc/src/sgml/backup.sgml
@@ -16,9 +16,9 @@
   There are three fundamentally different approaches to backing up
   <productname>PostgreSQL</productname> data:
   <itemizedlist>
-   <listitem><para><acronym>SQL</acronym> dump</para></listitem>
+   <listitem><para><acronym>SQL</acronym> dump (Logical Backup)</para></listitem>
    <listitem><para>File system level backup</para></listitem>
-   <listitem><para>Continuous archiving</para></listitem>
+   <listitem><para>Continuous archiving (Physical Backup)</para></listitem>
   </itemizedlist>
   Each has its own strengths and weaknesses; each is discussed in turn
   in the following sections.


### PR DESCRIPTION
**Reference Issues/PRs**
None

**What does this implement/fix? Explain your changes.**
As a new learner of Postgres DB, it will be helpful to have the high level categories mentioned along with backup types (_Physical backup_ and _Logical backup_)

**Any other comments?**
No