### PR TITLE
Add zero check for date_bin stride argument.

### DIFF
--- a/src/backend/utils/adt/timestamp.c
+++ b/src/backend/utils/adt/timestamp.c
@@ -3842,6 +3842,10 @@ timestamp_bin(PG_FUNCTION_ARGS)
 				 errmsg("timestamps cannot be binned into intervals containing months or years")));
 
 	stride_usecs = stride->day * USECS_PER_DAY + stride->time;
+	if (stride_usecs == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("stride cannot be zero")));
 
 	tm_diff = timestamp - origin;
 	tm_delta = tm_diff - tm_diff % stride_usecs;
@@ -4020,6 +4024,11 @@ timestamptz_bin(PG_FUNCTION_ARGS)
 				 errmsg("timestamps cannot be binned into intervals containing months or years")));
 
 	stride_usecs = stride->day * USECS_PER_DAY + stride->time;
+	if (stride_usecs == 0)
+		ereport(ERROR,
+				(errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+				 errmsg("stride cannot be zero")));
+		
 
 	tm_diff = timestamp - origin;
 	tm_delta = tm_diff - tm_diff % stride_usecs;


### PR DESCRIPTION
I'm trying beta version, thanks for implementing `date_bin`!

Query 

`SELECT date_bin('0 days'::interval, timestamp '1970-01-01 01:00:00' , timestamp '1970-01-01 00:00:00') `

returns error

```
ERROR:  floating-point exception
DETAIL:  An invalid floating-point operation was signaled. This probably means an out-of-range result or an invalid operation, such as division by zero.
SQL state: 22P01
```

Just a minor suggestion that showing the reason explicitly might be helpful.