### PR TITLE
Add LoongArch(loongarch64) support to s_lock.h.

### DIFF
--- a/src/include/storage/s_lock.h
+++ b/src/include/storage/s_lock.h
@@ -625,6 +625,45 @@ tas(volatile slock_t *lock)
 
 #endif	 /* __vax__ */
 
+#if defined(__loongarch__)
+#define HAS_TEST_AND_SET
+
+typedef unsigned int slock_t;
+
+#define TAS(lock) tas(lock)
+
+static __inline__ int
+tas(volatile slock_t *lock)
+{
+        register volatile slock_t *_l = lock;
+        register int _res;
+        register int _tmp;
+
+        __asm__ __volatile__(
+                "       ll.w     %0, %2    \n"
+                "       ori      %1, %0, 1  \n"
+                "       sc.w     %1, %2    \n"
+                "       xori     %1, %1, 1       \n"
+                "       or       %0, %0, %1  \n"
+                "       dbar 0              \n"
+:               "=&r" (_res), "=&r" (_tmp), "+R" (*_l)
+:               /* no inputs */
+:               "memory");
+        return _res;
+}
+
+#define S_UNLOCK(lock)  \
+do \
+{ \
+        __asm__ __volatile__( \
+                "       dbar 0              \n" \
+:               /* no outputs */ \
+:               /* no inputs */ \
+:               "memory"); \
+        *((volatile slock_t *) (lock)) = 0; \
+} while (0)
+
+#endif /* __loongarch__ */
 
 #if defined(__mips__) && !defined(__sgi)	/* non-SGI MIPS */
 #define HAS_TEST_AND_SET


### PR DESCRIPTION
Use the same gcc atomic functions as we do on newer LoongArch chips.