### PR TITLE
Update postgresql.conf.sample to fix huge_pages in Kubernetes

### DIFF
--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -127,7 +127,7 @@
 
 #shared_buffers = 128MB			# min 128kB
 					# (change requires restart)
-#huge_pages = try			# on, off, or try
+huge_pages = off			# on, off, or try
 					# (change requires restart)
 #huge_page_size = 0			# zero for system default
 					# (change requires restart)


### PR DESCRIPTION
When the system has huge_pages turned on initdb is using the "postgresql.conf.sample" file causing the process to crash in Kubernetes. Turning off huge pages in this file would resolve the issue.

Here are some links for further information

Crunchydata
https://github.com/CrunchyData/postgres-operator/issues/3477 https://github.com/CrunchyData/postgres-operator/issues/3039 https://github.com/CrunchyData/postgres-operator/issues/2258 https://github.com/CrunchyData/postgres-operator/issues/3126 https://github.com/CrunchyData/postgres-operator/issues/3421

Bitnami
https://github.com/bitnami/charts/issues/7901