### PR TITLE
Fix the bug when create schema authentication rolname.

### DIFF
--- a/src/backend/commands/schemacmds.c
+++ b/src/backend/commands/schemacmds.c
@@ -80,8 +80,11 @@ CreateSchemaCommand(CreateSchemaStmt *stmt, const char *queryString,
 		tuple = SearchSysCache1(AUTHOID, ObjectIdGetDatum(owner_uid));
 		if (!HeapTupleIsValid(tuple))
 			elog(ERROR, "cache lookup failed for role %u", owner_uid);
-		schemaName =
+
+		stmt->schemaname =
 			pstrdup(NameStr(((Form_pg_authid) GETSTRUCT(tuple))->rolname));
+		schemaName = stmt->schemaname;
+
 		ReleaseSysCache(tuple);
 	}
 


### PR DESCRIPTION
When we create schema authentication rolname create table/sequence/view sch.obj and sch is not NULL. In parse_utilcmd.c we will check whether schemaName and rolname are same or not. This will cause the database core due to strcmp will NULL pointer.

Here, we make CREATE SCHEMA AUTHENTICATION rolname is the same as CREATE SCHEMA rolname AUTHENTICATION rolname.