### PR TITLE
[Tip] Fix outdated instructions on $MANPATH

### DIFF
--- a/doc/src/sgml/installation.sgml
+++ b/doc/src/sgml/installation.sgml
@@ -3318,8 +3318,8 @@ set path = ( /usr/local/pgsql/bin $path )
     <indexterm>
      <primary><envar>MANPATH</envar></primary>
     </indexterm>
-    To enable your system to find the <application>man</application>
-    documentation, you need to add lines like the following to a
+    Systems that come with the [`manpath` utility](https://manpages.ubuntu.com/manpages/jammy/en/man5/manpath.5.html#search%20path) will automatically include the <application>man</application>
+    documentation in the search path. In case `manpath` is unavailable, you need to add lines like the following to a
     shell start-up file unless you installed into a location that is
     searched by default:
 <programlisting>

--- a/doc/src/sgml/installation.sgml
+++ b/doc/src/sgml/installation.sgml
@@ -3318,8 +3318,8 @@ set path = ( /usr/local/pgsql/bin $path )
     <indexterm>
      <primary><envar>MANPATH</envar></primary>
     </indexterm>
-    Systems that come with the [`manpath` utility](https://manpages.ubuntu.com/manpages/jammy/en/man5/manpath.5.html#search%20path) will automatically include the <application>man</application>
-    documentation in the search path. In case `manpath` is unavailable, you need to add lines like the following to a
+    Systems that come with the <application>manpath</application> utility will automatically include the <application>man</application>
+    documentation in the search path. In case <application>manpath</application> is unavailable, you need to add lines like the following to a
     shell start-up file unless you installed into a location that is
     searched by default:
 <programlisting>


### PR DESCRIPTION
This is more of a tip than a PR, as I’m uncomfortable sending things to public mailing lists. `pg` already uses the standard directory hierarchy that `manpath`  understands, so the manpages are searchable by default on most systems. Hope this helps you update your excellent docs!

https://manpages.ubuntu.com/manpages/jammy/en/man5/manpath.5.html#search%20path