### PR TITLE
Remove use less assert check during build GIN index. As we have the c…

### DIFF
--- a/src/backend/access/gin/ginpostinglist.c
+++ b/src/backend/access/gin/ginpostinglist.c
@@ -89,7 +89,6 @@ itemptr_to_uint64(const ItemPointer iptr)
 	uint64		val;
 
 	Assert(ItemPointerIsValid(iptr));
-	Assert(GinItemPointerGetOffsetNumber(iptr) < (1 << MaxHeapTuplesPerPageBits));
 
 	val = GinItemPointerGetBlockNumber(iptr);
 	val <<= MaxHeapTuplesPerPageBits;
@@ -323,7 +322,6 @@ ginPostingListDecodeAllSegments(GinPostingList *segment, int len, int *ndecoded_
 		}
 
 		/* copy the first item */
-		Assert(OffsetNumberIsValid(ItemPointerGetOffsetNumber(&segment->first)));
 		Assert(ndecoded == 0 || ginCompareItemPointers(&segment->first, &result[ndecoded - 1]) > 0);
 		result[ndecoded] = segment->first;
 		ndecoded++;


### PR DESCRIPTION
Remove use less assert check during build GIN index. As we have the commit bde7493d to Fix overflow check in GIN posting list encoding. It means different Table AM should be work for GIN index. As explained in commit bde7493d. The MaxOffsetNumber is the only limit for heap table. But the offset number of different Table AM may > MaxOffsetNumber. So it should be considered as expected.