### PR TITLE
Handle Windows non-blocking socket error

### DIFF
--- a/src/interfaces/libpq/fe-secure-gssapi.c
+++ b/src/interfaces/libpq/fe-secure-gssapi.c
@@ -430,8 +430,14 @@ gss_read(PGconn *conn, void *recv_buffer, size_t length, ssize_t *ret)
 	*ret = pqsecure_raw_read(conn, recv_buffer, length);
 	if (*ret < 0)
 	{
+#ifdef WIN32
+		if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR || SOCK_ERRNO == WSAEWOULDBLOCK)
+#else
 		if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+#endif
+		{
 			return PGRES_POLLING_READING;
+		}
 		else
 			return PGRES_POLLING_FAILED;
 	}


### PR DESCRIPTION
When using psql on Windows to connect to a PostgreSQL server, the connection fails with a non-blocking socket error. The error is due to the fact that the WSAEWOULDBLOCK error code is not handled in the gss_read function in fe-secure-gssapi.c.

Authored-by: Ning Wu <ningw@vmware.com>