### PR TITLE
Update fe-auth.c added support to SCRAM-SHA-256 if channel_binding is disabled

### DIFF
--- a/src/interfaces/libpq/fe-auth.c
+++ b/src/interfaces/libpq/fe-auth.c
@@ -513,6 +513,10 @@ pg_SASL_init(PGconn *conn, int payloadlen)
 				}
 #endif
 			}
+			else if (conn->channel_binding[0] == 'd')
+			{
+			    selected_mechanism = SCRAM_SHA_256_NAME;
+			}
 			else
 			{
 				/*


### PR DESCRIPTION
In this commit, I added support for SCRAM-SHA-256 authentication in the libpq library, specifically in the fe-auth.c file, when channel binding is disabled on the client side. This change is necessary when the client application attempts to connect to the server that offers SCRAM-SHA-256-PLUS authentication, but SSL termination occurs at the egress level in Kubernetes. In such cases, we encounter the error: "server offered SCRAM-SHA-256-PLUS authentication over a non-SSL connection." The client should be able to control and define channel binding independently to ensure a successful connection.