### PR TITLE
add support for the old naming libs convention on windows (ssleay32.lib and libeay32.lib)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1337,12 +1337,12 @@ if sslopt in ['auto', 'openssl']
 
   # via library + headers
   if not ssl.found()
-    ssl_lib = cc.find_library('ssl',
+    ssl_lib = cc.find_library(['ssl', 'ssleay32'],
       dirs: test_lib_d,
       header_include_directories: postgres_inc,
       has_headers: ['openssl/ssl.h', 'openssl/err.h'],
       required: openssl_required)
-    crypto_lib = cc.find_library('crypto',
+    crypto_lib = cc.find_library(['crypto', 'libeay32'],
       dirs: test_lib_d,
       required: openssl_required)
     if ssl_lib.found() and crypto_lib.found()


### PR DESCRIPTION
According to the postgresql-17 requirements https://www.postgresql.org/docs/17/install-requirements.html the minimum required version of openssl is 1.0.2.
In that version, the naming convention on windows is still ssleay32.[lib|dll] and libeay32.[lib|dll] instead of libssl.[lib|dll] and libcrypto.[lib|dll]. It changed in version 1.1.0 https://github.com/openssl/openssl/issues/10332#issuecomment-549027653
Thus there is a bug in meson.build as it only supports libssl.lib and libcrypto.lib, hence a simple patch that fixes the issue and supports both conventions.