### PR TITLE
add support for the old naming libs convention on windows (ssleay32.lib and libeay32.lib)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1343,14 +1343,35 @@ if sslopt in ['auto', 'openssl']
 
   # via library + headers
   if not ssl.found()
+    is_windows = build_system == 'windows'
+
+    ssl_lib_common_params = {
+        'dirs': test_lib_d,
+        'header_include_directories': postgres_inc,
+        'has_headers': ['openssl/ssl.h', 'openssl/err.h'],
+    }
     ssl_lib = cc.find_library('ssl',
-      dirs: test_lib_d,
-      header_include_directories: postgres_inc,
-      has_headers: ['openssl/ssl.h', 'openssl/err.h'],
-      required: openssl_required)
+        kwargs: ssl_lib_common_params,
+        required: openssl_required and not is_windows
+    )
+    # if 'ssl' is not found and it's windows, try 'ssleay32'
+    if not ssl_lib.found() and is_windows
+        ssl_lib = cc.find_library('ssleay32',
+            kwargs: ssl_lib_common_params,
+            required: openssl_required
+        )
+    endif
+
     crypto_lib = cc.find_library('crypto',
       dirs: test_lib_d,
-      required: openssl_required)
+      required: openssl_required and not is_windows)
+    # if 'crypto' is not found and it's windows, try 'libeay32'
+    if not crypto_lib.found() and is_windows
+      crypto_lib = cc.find_library('libeay32',
+        dirs: test_lib_d,
+        required: openssl_required)
+    endif
+
     if ssl_lib.found() and crypto_lib.found()
       ssl_int = [ssl_lib, crypto_lib]
       ssl = declare_dependency(dependencies: ssl_int, include_directories: postgres_inc)

--- a/meson.build
+++ b/meson.build
@@ -1351,8 +1351,8 @@ if sslopt in ['auto', 'openssl']
       'has_headers': ['openssl/ssl.h', 'openssl/err.h'],
     }
     ssl_lib = cc.find_library('ssl',
-        kwargs: ssl_lib_common_params,
-        required: openssl_required and not is_windows
+      kwargs: ssl_lib_common_params,
+      required: openssl_required and not is_windows
     )
     # if 'ssl' is not found and it's windows, try 'ssleay32'
     if not ssl_lib.found() and is_windows

--- a/meson.build
+++ b/meson.build
@@ -1346,9 +1346,9 @@ if sslopt in ['auto', 'openssl']
     is_windows = build_system == 'windows'
 
     ssl_lib_common_params = {
-        'dirs': test_lib_d,
-        'header_include_directories': postgres_inc,
-        'has_headers': ['openssl/ssl.h', 'openssl/err.h'],
+      'dirs': test_lib_d,
+      'header_include_directories': postgres_inc,
+      'has_headers': ['openssl/ssl.h', 'openssl/err.h'],
     }
     ssl_lib = cc.find_library('ssl',
         kwargs: ssl_lib_common_params,
@@ -1356,10 +1356,10 @@ if sslopt in ['auto', 'openssl']
     )
     # if 'ssl' is not found and it's windows, try 'ssleay32'
     if not ssl_lib.found() and is_windows
-        ssl_lib = cc.find_library('ssleay32',
-            kwargs: ssl_lib_common_params,
-            required: openssl_required
-        )
+      ssl_lib = cc.find_library('ssleay32',
+        kwargs: ssl_lib_common_params,
+        required: openssl_required
+      )
     endif
 
     crypto_lib = cc.find_library('crypto',


### PR DESCRIPTION
According to the postgresql-17 requirements https://www.postgresql.org/docs/17/install-requirements.html
the minimum required version of openssl is 1.0.2.
In that version, the naming convention on windows is still ssleay32.[lib|dll] and
libeay32.[lib|dll] instead of libssl.[lib|dll] and libcrypto.[lib|dll].
It changed in version 1.1.0 https://github.com/openssl/openssl/issues/10332#issuecomment-549027653
Thus there is a bug in meson.build as it only supports libssl.lib and libcrypto.lib,
hence a simple patch that fixes the issue and supports both conventions.
