### PR TITLE
Cache specific wrapper macros around SearchSysCache() functions

### DIFF
--- a/contrib/sepgsql/dml.c
+++ b/contrib/sepgsql/dml.c
@@ -39,7 +39,6 @@ static Bitmapset *
 fixup_whole_row_references(Oid relOid, Bitmapset *columns)
 {
 	Bitmapset  *result;
-	HeapTuple	tuple;
 	AttrNumber	natts;
 	AttrNumber	attno;
 	int			index;
@@ -50,11 +49,8 @@ fixup_whole_row_references(Oid relOid, Bitmapset *columns)
 		return columns;
 
 	/* obtain number of attributes */
-	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relOid));
-	if (!HeapTupleIsValid(tuple))
-		elog(ERROR, "cache lookup failed for relation %u", relOid);
-	natts = ((Form_pg_class) GETSTRUCT(tuple))->relnatts;
-	ReleaseSysCache(tuple);
+	with_reloid_cachetup(tup, classForm, relOid)
+		natts = classForm->relnatts;
 
 	/* remove bit 0 from column set, add in all the non-dropped columns */
 	result = bms_copy(columns);

--- a/src/backend/catalog/partition.c
+++ b/src/backend/catalog/partition.c
@@ -181,16 +181,11 @@ index_get_partition(Relation partition, Oid indexId)
 	foreach(l, idxlist)
 	{
 		Oid			partIdx = lfirst_oid(l);
-		HeapTuple	tup;
-		Form_pg_class classForm;
 		bool		ispartition;
 
-		tup = SearchSysCache1(RELOID, ObjectIdGetDatum(partIdx));
-		if (!HeapTupleIsValid(tup))
-			elog(ERROR, "cache lookup failed for relation %u", partIdx);
-		classForm = (Form_pg_class) GETSTRUCT(tup);
-		ispartition = classForm->relispartition;
-		ReleaseSysCache(tup);
+		with_reloid_cachetup(tup, classForm, partIdx)
+			ispartition = classForm->relispartition;
+
 		if (!ispartition)
 			continue;
 		if (get_partition_parent(partIdx, false) == indexId)

--- a/src/backend/catalog/pg_inherits.c
+++ b/src/backend/catalog/pg_inherits.c
@@ -354,15 +354,11 @@ find_all_inheritors(Oid parentrelId, LOCKMODE lockmode, List **numparents)
 bool
 has_subclass(Oid relationId)
 {
-	HeapTuple	tuple;
 	bool		result;
 
-	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relationId));
-	if (!HeapTupleIsValid(tuple))
-		elog(ERROR, "cache lookup failed for relation %u", relationId);
+	with_reloid_cachetup(tup, classForm, relationId)
+		result = classForm->relhassubclass;
 
-	result = ((Form_pg_class) GETSTRUCT(tuple))->relhassubclass;
-	ReleaseSysCache(tuple);
 	return result;
 }
 


### PR DESCRIPTION
These have following benefits

1. Macroise boilerplate code, thus focusing on the actual use of cached catalog entry.

2. Avoid errors caused by using wrong SearchSysCache functions

Cons: May have performance impact since these macros add additional CPU instructions.

Author: Ashutosh Bapat