### PR TITLE
Add support for bitcode generation on meson builds

### DIFF
--- a/contrib/amcheck/meson.build
+++ b/contrib/amcheck/meson.build
@@ -15,7 +15,11 @@ amcheck = shared_module('amcheck',
   amcheck_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += amcheck
+
+if llvm.found()
+  contrib_targets += amcheck
+  llvm_contrib_sources += amcheck_sources
+endif
 
 install_data(
   'amcheck.control',

--- a/contrib/auth_delay/meson.build
+++ b/contrib/auth_delay/meson.build
@@ -14,4 +14,8 @@ auth_delay = shared_module('auth_delay',
   auth_delay_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += auth_delay
+
+if llvm.found()
+  contrib_targets += auth_delay
+  llvm_contrib_sources += auth_delay_sources
+endif

--- a/contrib/auto_explain/meson.build
+++ b/contrib/auto_explain/meson.build
@@ -14,7 +14,11 @@ auto_explain = shared_module('auto_explain',
   auto_explain_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += auto_explain
+
+if llvm.found()
+  contrib_targets += auto_explain
+  llvm_contrib_sources += auto_explain_sources
+endif
 
 tests += {
   'name': 'auto_explain',

--- a/contrib/basebackup_to_shell/meson.build
+++ b/contrib/basebackup_to_shell/meson.build
@@ -14,7 +14,11 @@ basebackup_to_shell = shared_module('basebackup_to_shell',
   basebackup_to_shell_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += basebackup_to_shell
+
+if llvm.found()
+  contrib_targets += basebackup_to_shell
+  llvm_contrib_sources += basebackup_to_shell_sources
+endif
 
 tests += {
   'name': 'basebackup_to_shell',

--- a/contrib/basic_archive/meson.build
+++ b/contrib/basic_archive/meson.build
@@ -14,7 +14,11 @@ basic_archive = shared_module('basic_archive',
   basic_archive_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += basic_archive
+
+if llvm.found()
+  contrib_targets += basic_archive
+  llvm_contrib_sources += basic_archive_sources
+endif
 
 tests += {
   'name': 'basic_archive',

--- a/contrib/bloom/meson.build
+++ b/contrib/bloom/meson.build
@@ -20,7 +20,12 @@ bloom = shared_module('bloom',
   c_pch: pch_postgres_h,
   kwargs: contrib_mod_args,
 )
-contrib_targets += bloom
+
+if llvm.found()
+  contrib_targets += bloom
+  llvm_contrib_sources += bloom_sources
+endif
+
 
 install_data(
   'bloom.control',

--- a/contrib/bool_plperl/meson.build
+++ b/contrib/bool_plperl/meson.build
@@ -14,7 +14,7 @@ if host_system == 'windows'
     '--FILEDESC', 'bool_plperl - bool transform for plperl',])
 endif
 
-bool_plperl = shared_module('bool_plperl',
+bool_plperl= shared_module('bool_plperl',
   bool_plperl_sources,
   include_directories: [plperl_inc, include_directories('.')],
   kwargs: contrib_mod_args + {
@@ -23,7 +23,24 @@ bool_plperl = shared_module('bool_plperl',
     'build_rpath': '@0@/CORE'.format(archlibexp),
   },
 )
-contrib_targets += bool_plperl
+
+if llvm.found()
+  llvm_contrib_bool_plperl_cflags = [
+    '-I@BUILD_ROOT@/contrib/bool_plperl',
+    '-I@SOURCE_ROOT@/contrib/bool_plperl',
+    '-I@BUILD_ROOT@/src/pl/plperl',
+    '-I@SOURCE_ROOT@/src/pl/plperl',
+  ]
+
+  llvm_gen_contrib_bool_plperl = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_bool_plperl_cflags + perl_ccflags,
+    depends: bool_plperl,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_bool_plperl.process(bool_plperl_sources)
+endif
 
 install_data(
   'bool_plperl.control',

--- a/contrib/btree_gin/meson.build
+++ b/contrib/btree_gin/meson.build
@@ -14,7 +14,11 @@ btree_gin = shared_module('btree_gin',
   btree_gin_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += btree_gin
+
+if llvm.found()
+  contrib_targets += btree_gin
+  llvm_contrib_sources += btree_gin_sources
+endif
 
 install_data(
   'btree_gin.control',

--- a/contrib/btree_gist/meson.build
+++ b/contrib/btree_gist/meson.build
@@ -38,7 +38,11 @@ btree_gist = shared_module('btree_gist',
   c_pch: pch_postgres_h,
   kwargs: contrib_mod_args,
 )
-contrib_targets += btree_gist
+
+if llvm.found()
+  contrib_targets += btree_gist
+  llvm_contrib_sources += btree_gist_sources
+endif
 
 install_data(
   'btree_gist.control',

--- a/contrib/citext/meson.build
+++ b/contrib/citext/meson.build
@@ -14,7 +14,11 @@ citext = shared_module('citext',
   citext_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += citext
+
+if llvm.found()
+  contrib_targets += citext
+  llvm_contrib_sources += citext_sources
+endif
 
 install_data(
   'citext.control',

--- a/contrib/cube/meson.build
+++ b/contrib/cube/meson.build
@@ -11,6 +11,7 @@ cube_scan = custom_target('cubescan',
 )
 generated_sources += cube_scan
 cube_sources += cube_scan
+bc_cube_sources = cube_sources
 
 cube_parse = custom_target('cubeparse',
   input: 'cubeparse.y',
@@ -18,6 +19,7 @@ cube_parse = custom_target('cubeparse',
 )
 generated_sources += cube_parse.to_list()
 cube_sources += cube_parse
+bc_cube_sources += cube_parse[0]
 
 if host_system == 'windows'
   cube_sources += rc_lib_gen.process(win32ver_rc, extra_args: [
@@ -30,7 +32,22 @@ cube = shared_module('cube',
   include_directories: include_directories('.'),
   kwargs: contrib_mod_args,
 )
-contrib_targets += cube
+
+if llvm.found()
+  llvm_contrib_cube_cflags = [
+    '-I@BUILD_ROOT@/contrib/cube',
+    '-I@SOURCE_ROOT@/contrib/cube',
+  ]
+
+  llvm_gen_contrib_cube = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_cube_cflags,
+    depends: cube,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_cube.process(bc_cube_sources)
+endif
 
 install_data(
   'cube.control',

--- a/contrib/dblink/meson.build
+++ b/contrib/dblink/meson.build
@@ -18,6 +18,10 @@ dblink = shared_module('dblink',
 )
 contrib_targets += dblink
 
+# if llvm.found()
+#   llvm_contrib_sources += dblink_sources
+# endif
+
 install_data(
   'dblink.control',
   'dblink--1.0--1.1.sql',

--- a/contrib/dict_int/meson.build
+++ b/contrib/dict_int/meson.build
@@ -14,7 +14,11 @@ dict_int = shared_module('dict_int',
   dict_int_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += dict_int
+
+if llvm.found()
+  contrib_targets += dict_int
+  llvm_contrib_sources += dict_int_sources
+endif
 
 install_data(
   'dict_int.control',

--- a/contrib/dict_xsyn/meson.build
+++ b/contrib/dict_xsyn/meson.build
@@ -14,7 +14,11 @@ dict_xsyn = shared_module('dict_xsyn',
   dict_xsyn_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += dict_xsyn
+
+if llvm.found()
+  contrib_targets += dict_xsyn
+  llvm_contrib_sources += dict_xsyn_sources
+endif
 
 install_data(
   'dict_xsyn.control',

--- a/contrib/earthdistance/meson.build
+++ b/contrib/earthdistance/meson.build
@@ -14,7 +14,11 @@ earthdistance = shared_module('earthdistance',
   earthdistance_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += earthdistance
+
+if llvm.found()
+  contrib_targets += earthdistance
+  llvm_contrib_sources += earthdistance_sources
+endif
 
 install_data(
   'earthdistance.control',

--- a/contrib/file_fdw/meson.build
+++ b/contrib/file_fdw/meson.build
@@ -14,7 +14,11 @@ file_fdw = shared_module('file_fdw',
   file_fdw_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += file_fdw
+
+if llvm.found()
+  contrib_targets += file_fdw
+  llvm_contrib_sources += file_fdw_sources
+endif
 
 install_data(
   'file_fdw.control',

--- a/contrib/fuzzystrmatch/meson.build
+++ b/contrib/fuzzystrmatch/meson.build
@@ -6,6 +6,8 @@ fuzzystrmatch_sources = files(
   'fuzzystrmatch.c',
 )
 
+bc_fuzzystrmatch_sources = fuzzystrmatch_sources
+
 daitch_mokotoff_h = custom_target('daitch_mokotoff',
   input: 'daitch_mokotoff_header.pl',
   output: 'daitch_mokotoff.h',
@@ -27,6 +29,21 @@ fuzzystrmatch = shared_module('fuzzystrmatch',
 )
 contrib_targets += fuzzystrmatch
 
+if llvm.found()
+  llvm_contrib_fuzzystrmatch_cflags = [
+    '-I@BUILD_ROOT@/contrib/fuzzystrmatch',
+    '-I@SOURCE_ROOT@/contrib/fuzzystrmatch',
+  ]
+
+  llvm_gen_contrib_fuzzystrmatch = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_fuzzystrmatch_cflags,
+    depends: daitch_mokotoff_h,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_fuzzystrmatch.process(bc_fuzzystrmatch_sources)
+endif
 install_data(
   'fuzzystrmatch.control',
   'fuzzystrmatch--1.0--1.1.sql',

--- a/contrib/hstore/meson.build
+++ b/contrib/hstore/meson.build
@@ -23,7 +23,11 @@ hstore = shared_module('hstore',
   c_pch: pch_postgres_h,
   kwargs: contrib_mod_args,
 )
-contrib_targets += hstore
+
+if llvm.found()
+  contrib_targets += hstore
+  llvm_contrib_sources += hstore_sources
+endif
 
 install_data(
   'hstore.control',

--- a/contrib/hstore_plperl/meson.build
+++ b/contrib/hstore_plperl/meson.build
@@ -23,7 +23,24 @@ hstore_plperl = shared_module('hstore_plperl',
     'build_rpath': '@0@/CORE'.format(archlibexp),
   },
 )
-contrib_targets += hstore_plperl
+
+if llvm.found()
+  llvm_contrib_hstore_plperl_cflags = [
+    '-I@BUILD_ROOT@/src/pl/plperl',
+    '-I@SOURCE_ROOT@/src/pl/plperl',
+    '-I@SOURCE_ROOT@/contrib',
+    '-I@SOURCE_ROOT@/contrib/hstore',
+  ]
+
+  llvm_gen_contrib_hstore_plperl = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_hstore_plperl_cflags + perl_ccflags,
+    depends: hstore_plperl,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_hstore_plperl.process(hstore_plperl_sources)
+endif
 
 install_data(
   'hstore_plperl.control',

--- a/contrib/hstore_plpython/meson.build
+++ b/contrib/hstore_plpython/meson.build
@@ -22,7 +22,27 @@ hstore_plpython = shared_module('hstore_plpython3',
     'dependencies': [python3_dep, contrib_mod_args['dependencies']],
   },
 )
-contrib_targets += hstore_plpython
+
+if llvm.found()
+  pyinc = python3_inst.get_variable('INCLUDEPY')
+  llvm_contrib_hstore_plpython_cflags = [
+    '-I@SOURCE_ROOT@/src/pl/plpython',
+    '-I@SOURCE_ROOT@/contrib',
+    '-I@SOURCE_ROOT@/contrib/hstore',
+    '-DPLPYTHON_LIBNAME="plpython3"',
+    '-I@0@'.format(pyinc),
+  ]
+
+  llvm_gen_contrib_hstore_plpython = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_hstore_plpython_cflags,
+    depends: hstore_plpython,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_hstore_plpython.process(hstore_plpython_sources)
+endif
+
 
 install_data(
   'hstore_plpython3u--1.0.sql',

--- a/contrib/intarray/meson.build
+++ b/contrib/intarray/meson.build
@@ -20,7 +20,11 @@ intarray = shared_module('_int',
   intarray_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += intarray
+
+if llvm.found()
+  contrib_targets += intarray
+  llvm_contrib_sources += intarray_sources
+endif
 
 install_data(
   'intarray.control',

--- a/contrib/isn/meson.build
+++ b/contrib/isn/meson.build
@@ -14,7 +14,11 @@ isn = shared_module('isn',
   isn_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += isn
+
+if llvm.found()
+  contrib_targets += isn
+  llvm_contrib_sources += isn_sources
+endif
 
 install_data(
   'isn.control',

--- a/contrib/jsonb_plperl/meson.build
+++ b/contrib/jsonb_plperl/meson.build
@@ -23,7 +23,23 @@ jsonb_plperl = shared_module('jsonb_plperl',
     'build_rpath': '@0@/CORE'.format(archlibexp),
   },
 )
-contrib_targets += jsonb_plperl
+
+if llvm.found()
+  llvm_contrib_jsonb_plperl_cflags = [
+    '-I@BUILD_ROOT@/src/pl/plperl',
+    '-I@SOURCE_ROOT@/src/pl/plperl',
+  ]
+
+  llvm_gen_contrib_jsonb_plperl = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_jsonb_plperl_cflags + perl_ccflags,
+    depends: jsonb_plperl,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_jsonb_plperl.process(jsonb_plperl_sources)
+endif
+
 
 install_data(
   'jsonb_plperl.control',

--- a/contrib/jsonb_plpython/meson.build
+++ b/contrib/jsonb_plpython/meson.build
@@ -22,7 +22,26 @@ jsonb_plpython = shared_module('jsonb_plpython3',
     'dependencies': [python3_dep, contrib_mod_args['dependencies']],
   },
 )
-contrib_targets += jsonb_plpython
+
+if llvm.found()
+  pyinc = python3_inst.get_variable('INCLUDEPY')
+  llvm_contrib_jsonb_plpython_cflags = [
+    '-I@SOURCE_ROOT@/src/pl/plpython',
+    '-I@SOURCE_ROOT@/contrib',
+    '-I@SOURCE_ROOT@/contrib/hstore',
+    '-DPLPYTHON_LIBNAME="plpython3"',
+    '-I@0@'.format(pyinc),
+  ]
+
+  llvm_gen_contrib_jsonb_plpython = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_jsonb_plpython_cflags,
+    depends: jsonb_plpython,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_jsonb_plpython.process(jsonb_plpython_sources)
+endif
 
 install_data(
   'jsonb_plpython3u.control',

--- a/contrib/lo/meson.build
+++ b/contrib/lo/meson.build
@@ -14,7 +14,11 @@ lo = shared_module('lo',
   lo_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += lo
+
+if llvm.found()
+  contrib_targets += lo
+  llvm_contrib_sources += lo_sources
+endif
 
 install_data(
   'lo.control',

--- a/contrib/ltree/meson.build
+++ b/contrib/ltree/meson.build
@@ -25,7 +25,11 @@ ltree = shared_module('ltree',
   ltree_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += ltree
+
+if llvm.found()
+  contrib_targets += ltree
+  llvm_contrib_sources += ltree_sources
+endif
 
 install_data(
   'ltree.control',

--- a/contrib/ltree_plpython/meson.build
+++ b/contrib/ltree_plpython/meson.build
@@ -22,7 +22,26 @@ ltree_plpython = shared_module('ltree_plpython3',
     'dependencies': [python3_dep, contrib_mod_args['dependencies']],
   },
 )
-contrib_targets += ltree_plpython
+
+if llvm.found()
+  pyinc = python3_inst.get_variable('INCLUDEPY')
+  llvm_contrib_ltree_plpython_cflags = [
+    '-I@SOURCE_ROOT@/src/pl/plpython',
+    '-I@SOURCE_ROOT@/contrib',
+    '-I@SOURCE_ROOT@/contrib/ltree',
+    '-DPLPYTHON_LIBNAME="plpython3"',
+    '-I@0@'.format(pyinc),
+  ]
+
+  llvm_gen_contrib_ltree_plpython = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_ltree_plpython_cflags,
+    depends: ltree_plpython,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_ltree_plpython.process(ltree_plpython_sources)
+endif
 
 install_data(
   'ltree_plpython3u--1.0.sql',

--- a/contrib/oid2name/meson.build
+++ b/contrib/oid2name/meson.build
@@ -17,6 +17,10 @@ oid2name = executable('oid2name',
 )
 contrib_targets += oid2name
 
+# if llvm.found()
+#   llvm_contrib_sources += oid2name_sources
+# endif
+
 tests += {
   'name': 'oid2name',
   'sd': meson.current_source_dir(),

--- a/contrib/pageinspect/meson.build
+++ b/contrib/pageinspect/meson.build
@@ -21,7 +21,11 @@ pageinspect = shared_module('pageinspect',
   pageinspect_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += pageinspect
+
+if llvm.found()
+  contrib_targets += pageinspect
+  llvm_contrib_sources += pageinspect_sources
+endif
 
 install_data(
   'pageinspect--1.0--1.1.sql',

--- a/contrib/passwordcheck/meson.build
+++ b/contrib/passwordcheck/meson.build
@@ -24,7 +24,11 @@ passwordcheck = shared_module('passwordcheck',
     'dependencies': contrib_mod_args.get('dependencies') + passwordcheck_deps,
   }
 )
-contrib_targets += passwordcheck
+
+if llvm.found()
+  contrib_targets += passwordcheck
+  llvm_contrib_sources += passwordcheck_sources
+endif
 
 tests += {
   'name': 'passwordcheck',

--- a/contrib/pg_buffercache/meson.build
+++ b/contrib/pg_buffercache/meson.build
@@ -14,7 +14,11 @@ pg_buffercache = shared_module('pg_buffercache',
   pg_buffercache_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += pg_buffercache
+
+if llvm.found()
+  contrib_targets += pg_buffercache
+  llvm_contrib_sources += pg_buffercache_sources
+endif
 
 install_data(
   'pg_buffercache--1.0--1.1.sql',

--- a/contrib/pg_freespacemap/meson.build
+++ b/contrib/pg_freespacemap/meson.build
@@ -14,7 +14,11 @@ pg_freespacemap = shared_module('pg_freespacemap',
   pg_freespacemap_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += pg_freespacemap
+
+if llvm.found()
+  contrib_targets += pg_freespacemap
+  llvm_contrib_sources += pg_freespacemap_sources
+endif
 
 install_data(
   'pg_freespacemap--1.0--1.1.sql',

--- a/contrib/pg_logicalinspect/meson.build
+++ b/contrib/pg_logicalinspect/meson.build
@@ -14,7 +14,11 @@ pg_logicalinspect = shared_module('pg_logicalinspect',
       'dependencies': contrib_mod_args['dependencies'],
   },
 )
-contrib_targets += pg_logicalinspect
+
+if llvm.found()
+  contrib_targets += pg_logicalinspect
+  llvm_contrib_sources += pg_logicalinspect_sources
+endif
 
 install_data(
   'pg_logicalinspect.control',

--- a/contrib/pg_prewarm/meson.build
+++ b/contrib/pg_prewarm/meson.build
@@ -15,7 +15,11 @@ pg_prewarm = shared_module('pg_prewarm',
   pg_prewarm_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += pg_prewarm
+
+if llvm.found()
+  contrib_targets += pg_prewarm
+  llvm_contrib_sources += pg_prewarm_sources
+endif
 
 install_data(
   'pg_prewarm--1.0--1.1.sql',

--- a/contrib/pg_stat_statements/meson.build
+++ b/contrib/pg_stat_statements/meson.build
@@ -16,7 +16,11 @@ pg_stat_statements = shared_module('pg_stat_statements',
     'dependencies': contrib_mod_args['dependencies'],
   },
 )
-contrib_targets += pg_stat_statements
+
+if llvm.found()
+  contrib_targets += pg_stat_statements
+  llvm_contrib_sources += pg_stat_statements_sources
+endif
 
 install_data(
   'pg_stat_statements.control',

--- a/contrib/pg_surgery/meson.build
+++ b/contrib/pg_surgery/meson.build
@@ -14,7 +14,11 @@ pg_surgery = shared_module('pg_surgery',
   pg_surgery_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += pg_surgery
+
+if llvm.found()
+  contrib_targets += pg_surgery
+  llvm_contrib_sources += pg_surgery_sources
+endif
 
 install_data(
   'pg_surgery--1.0.sql',

--- a/contrib/pg_trgm/meson.build
+++ b/contrib/pg_trgm/meson.build
@@ -18,7 +18,11 @@ pg_trgm = shared_module('pg_trgm',
   c_pch: pch_postgres_h,
   kwargs: contrib_mod_args,
 )
-contrib_targets += pg_trgm
+
+if llvm.found()
+  contrib_targets += pg_trgm
+  llvm_contrib_sources += pg_trgm_sources
+endif
 
 install_data(
   'pg_trgm--1.0--1.1.sql',

--- a/contrib/pg_visibility/meson.build
+++ b/contrib/pg_visibility/meson.build
@@ -14,7 +14,11 @@ pg_visibility = shared_module('pg_visibility',
   pg_visibility_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += pg_visibility
+
+if llvm.found()
+  contrib_targets += pg_visibility
+  llvm_contrib_sources += pg_visibility_sources
+endif
 
 install_data(
   'pg_visibility--1.0--1.1.sql',

--- a/contrib/pg_walinspect/meson.build
+++ b/contrib/pg_walinspect/meson.build
@@ -14,7 +14,11 @@ pg_walinspect = shared_module('pg_walinspect',
       'dependencies': contrib_mod_args['dependencies'],
   },
 )
-contrib_targets += pg_walinspect
+
+if llvm.found()
+  contrib_targets += pg_walinspect
+  llvm_contrib_sources += pg_walinspect_sources
+endif
 
 install_data(
   'pg_walinspect.control',

--- a/contrib/pgcrypto/meson.build
+++ b/contrib/pgcrypto/meson.build
@@ -86,7 +86,11 @@ pgcrypto = shared_module('pgcrypto',
     'dependencies': [pgcrypto_deps, contrib_mod_args['dependencies']]
   },
 )
-contrib_targets += pgcrypto
+
+if llvm.found()
+  contrib_targets += pgcrypto
+  llvm_contrib_sources += pgcrypto_sources
+endif
 
 install_data(
   'pgcrypto--1.0--1.1.sql',

--- a/contrib/pgrowlocks/meson.build
+++ b/contrib/pgrowlocks/meson.build
@@ -14,7 +14,11 @@ pgrowlocks = shared_module('pgrowlocks',
   pgrowlocks_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += pgrowlocks
+
+if llvm.found()
+  contrib_targets += pgrowlocks
+  llvm_contrib_sources += pgrowlocks_sources
+endif
 
 install_data(
   'pgrowlocks--1.0--1.1.sql',

--- a/contrib/pgstattuple/meson.build
+++ b/contrib/pgstattuple/meson.build
@@ -17,7 +17,11 @@ pgstattuple = shared_module('pgstattuple',
   c_pch: pch_postgres_h,
   kwargs: contrib_mod_args,
 )
-contrib_targets += pgstattuple
+
+if llvm.found()
+  contrib_targets += pgstattuple
+  llvm_contrib_sources += pgstattuple_sources
+endif
 
 install_data(
   'pgstattuple--1.0--1.1.sql',

--- a/contrib/postgres_fdw/meson.build
+++ b/contrib/postgres_fdw/meson.build
@@ -20,7 +20,21 @@ postgres_fdw = shared_module('postgres_fdw',
     'dependencies': contrib_mod_args['dependencies'] + [libpq],
   },
 )
-contrib_targets += postgres_fdw
+
+if llvm.found()
+  llvm_contrib_fdw_cflags = [
+    '-I@SOURCE_ROOT@/src/interfaces/libpq',
+  ]
+
+  llvm_gen_contrib_fdw = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_fdw_cflags,
+    depends: postgres_fdw,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_fdw.process(postgres_fdw_sources)
+endif
 
 install_data(
   'postgres_fdw.control',

--- a/contrib/seg/meson.build
+++ b/contrib/seg/meson.build
@@ -4,6 +4,8 @@ seg_sources = files(
   'seg.c',
 )
 
+bc_seg_sources= []
+
 seg_scan = custom_target('segscan',
   input: 'segscan.l',
   output: 'segscan.c',
@@ -11,6 +13,7 @@ seg_scan = custom_target('segscan',
 )
 generated_sources += seg_scan
 seg_sources += seg_scan
+bc_seg_sources += seg_scan
 
 seg_parse = custom_target('segparse',
   input: 'segparse.y',
@@ -18,6 +21,7 @@ seg_parse = custom_target('segparse',
 )
 generated_sources += seg_parse.to_list()
 seg_sources += seg_parse
+bc_seg_sources += seg_parse[0]
 
 if host_system == 'windows'
   seg_sources += rc_lib_gen.process(win32ver_rc, extra_args: [
@@ -30,7 +34,22 @@ seg = shared_module('seg',
   include_directories: include_directories('.'),
   kwargs: contrib_mod_args,
 )
-contrib_targets += seg
+
+if llvm.found()
+  llvm_contrib_seg_cflags = [
+    '-I@BUILD_ROOT@/contrib/seg',
+    '-I@SOURCE_ROOT@/contrib/seg',
+  ]
+
+  llvm_gen_contrib_seg = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args + llvm_contrib_seg_cflags,
+    depends: seg,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom_contrib += llvm_gen_contrib_seg.process(bc_seg_sources)
+endif
 
 install_data(
   'seg.control',

--- a/contrib/sepgsql/meson.build
+++ b/contrib/sepgsql/meson.build
@@ -40,6 +40,10 @@ contrib_targets += custom_target('sepgsql.sql',
   install_dir: dir_data / 'contrib',
 )
 
+if llvm.found()
+  llvm_contrib_sources += sepgsql_sources
+endif
+
 tests += {
   'name': 'sepgsql',
   'sd': meson.current_source_dir(),

--- a/contrib/spi/meson.build
+++ b/contrib/spi/meson.build
@@ -14,7 +14,11 @@ autoinc = shared_module('autoinc',
   autoinc_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += autoinc
+
+if llvm.found()
+  contrib_targets += autoinc
+  llvm_contrib_sources += autoinc_sources
+endif
 
 install_data('autoinc.control', 'autoinc--1.0.sql',
   kwargs: contrib_data_args,
@@ -39,7 +43,11 @@ insert_username = shared_module('insert_username',
   insert_username_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += insert_username
+
+if llvm.found()
+  contrib_targets += insert_username
+  llvm_contrib_sources += insert_username_sources
+endif
 
 install_data(
   'insert_username.control',
@@ -66,7 +74,11 @@ moddatetime = shared_module('moddatetime',
   moddatetime_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += moddatetime
+
+if llvm.found()
+  contrib_targets += moddatetime
+  llvm_contrib_sources += moddatetime_sources
+endif
 
 install_data(
   'moddatetime.control',
@@ -98,7 +110,11 @@ refint = shared_module('refint',
   c_args: refint_cflags,
   kwargs: contrib_mod_args,
 )
-contrib_targets += refint
+
+if llvm.found()
+  contrib_targets += refint
+  llvm_contrib_sources += refint_sources
+endif
 
 install_data('refint.control', 'refint--1.0.sql',
   kwargs: contrib_data_args,

--- a/contrib/sslinfo/meson.build
+++ b/contrib/sslinfo/meson.build
@@ -20,7 +20,11 @@ sslinfo = shared_module('sslinfo',
     'dependencies': [ssl, contrib_mod_args['dependencies']],
   }
 )
-contrib_targets += sslinfo
+
+if llvm.found()
+  contrib_targets += sslinfo
+  llvm_contrib_sources += sslinfo_sources
+endif
 
 install_data(
   'sslinfo--1.0--1.1.sql',

--- a/contrib/tablefunc/meson.build
+++ b/contrib/tablefunc/meson.build
@@ -14,7 +14,11 @@ tablefunc = shared_module('tablefunc',
   tablefunc_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += tablefunc
+
+if llvm.found()
+  contrib_targets += tablefunc
+  llvm_contrib_sources += tablefunc_sources
+endif
 
 install_data(
   'tablefunc--1.0.sql',

--- a/contrib/tcn/meson.build
+++ b/contrib/tcn/meson.build
@@ -14,7 +14,11 @@ tcn = shared_module('tcn',
   tcn_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += tcn
+
+if llvm.found()
+  contrib_targets += tcn
+  llvm_contrib_sources += tcn_sources
+endif
 
 install_data(
   'tcn--1.0.sql',

--- a/contrib/test_decoding/meson.build
+++ b/contrib/test_decoding/meson.build
@@ -14,7 +14,11 @@ test_decoding = shared_module('test_decoding',
   test_decoding_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += test_decoding
+
+if llvm.found()
+  contrib_targets += test_decoding
+  llvm_contrib_sources += test_decoding_sources
+endif
 
 tests += {
   'name': 'test_decoding',

--- a/contrib/tsm_system_rows/meson.build
+++ b/contrib/tsm_system_rows/meson.build
@@ -14,7 +14,11 @@ tsm_system_rows = shared_module('tsm_system_rows',
   tsm_system_rows_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += tsm_system_rows
+
+if llvm.found()
+  contrib_targets += tsm_system_rows
+  llvm_contrib_sources += tsm_system_rows_sources
+endif
 
 install_data(
   'tsm_system_rows--1.0.sql',

--- a/contrib/tsm_system_time/meson.build
+++ b/contrib/tsm_system_time/meson.build
@@ -14,7 +14,11 @@ tsm_system_time = shared_module('tsm_system_time',
   tsm_system_time_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += tsm_system_time
+
+if llvm.found()
+  contrib_targets += tsm_system_time
+  llvm_contrib_sources += tsm_system_time_sources
+endif
 
 install_data(
   'tsm_system_time--1.0.sql',

--- a/contrib/unaccent/meson.build
+++ b/contrib/unaccent/meson.build
@@ -14,7 +14,11 @@ unaccent = shared_module('unaccent',
   unaccent_sources,
   kwargs: contrib_mod_args,
 )
-contrib_targets += unaccent
+
+if llvm.found()
+  contrib_targets += unaccent
+  llvm_contrib_sources += unaccent_sources
+endif
 
 install_data(
   'unaccent--1.0--1.1.sql',

--- a/contrib/uuid-ossp/meson.build
+++ b/contrib/uuid-ossp/meson.build
@@ -20,7 +20,11 @@ uuid_ossp = shared_module('uuid-ossp',
     'dependencies': [uuid, contrib_mod_args['dependencies']],
   },
 )
-contrib_targets += uuid_ossp
+
+if llvm.found()
+  contrib_targets += uuid_ossp
+  llvm_contrib_sources += uuid_ossp_sources
+endif
 
 install_data(
   'uuid-ossp--1.0--1.1.sql',

--- a/contrib/vacuumlo/meson.build
+++ b/contrib/vacuumlo/meson.build
@@ -17,6 +17,10 @@ vacuumlo = executable('vacuumlo',
 )
 contrib_targets += vacuumlo
 
+# if llvm.found()
+#   llvm_contrib_sources += vacuumlo_sources
+# endif
+
 tests += {
   'name': 'vacuumlo',
   'sd': meson.current_source_dir(),

--- a/contrib/xml2/meson.build
+++ b/contrib/xml2/meson.build
@@ -22,7 +22,11 @@ xml2 = shared_module('pgxml',
     'dependencies': [libxml, libxslt, contrib_mod_args['dependencies']],
   },
 )
-contrib_targets += xml2
+
+if llvm.found()
+  contrib_targets += xml2
+  llvm_contrib_sources += xml2_sources
+endif
 
 install_data(
   'xml2--1.0--1.1.sql',

--- a/meson.build
+++ b/meson.build
@@ -857,6 +857,10 @@ if add_languages('cpp', required: llvmopt, native: false)
     bitcode_cflags += '-I@BUILD_ROOT@/src/include'
     bitcode_cflags += '-I@BUILD_ROOT@/src/backend/utils/misc'
     bitcode_cflags += '-I@SOURCE_ROOT@/src/include'
+    extra_inc = get_option('extra_include_dirs')
+    if extra_inc.length() > 0
+      bitcode_cflags += extra_inc
+    endif
 
   endif
 elif llvmopt.auto()
@@ -3108,9 +3112,14 @@ generated_sources_ac = {}
 # contrib source files used to generate bitcode (--with-llvm)
 llvm_contrib_sources = []
 
-# bitcode files generated from generated source files
+# bitcode files generated from generated source files (flex, bison, etc)_
 bc_generated_sources = []
-bc_gen_custom = []
+
+# bitcode files generated from generated source files in backend with custom CFLAGS
+bc_gen_custom_backend = []
+
+# bitcode files generated from generated source files in contrib with custom CFLAGS
+bc_gen_custom_contrib = []
 
 # First visit src/include - all targets creating headers are defined
 # within. That makes it easy to add the necessary dependencies for the
@@ -3346,7 +3355,14 @@ if llvm.found()
 
   llvm_gen = generator(llvm_irgen_command,
     arguments: llvm_irgen_args + bitcode_cflags,
-    depends: [transitive_depend_target] + contrib_targets,
+    depends: [transitive_depend_target, postgres_lib],
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  llvm_gen_contrib = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + pg_mod_c_args,
+    depends: [transitive_depend_target, contrib_targets],
     depfile: '@BASENAME@.c.bc.d',
     output: '@PLAINNAME@.bc',
   )
@@ -3364,12 +3380,11 @@ if llvm.found()
 
   bc_gen_sources = llvm_gen.process(generated_filenames)
 
-  # bc_contrib_sources = llvm_gen.process(llvm_contrib_sources)
+  bc_contrib_sources = llvm_gen_contrib.process(llvm_contrib_sources)
 
   postgres_llvm = custom_target('bitcode',
     output: ['bitcode'],
-    # input: [bc_backend_sources, bc_generated_sources, bc_contrib_sources],
-    input: [bc_backend_sources, bc_gen_sources, bc_gen_custom],
+    input: [bc_backend_sources, bc_gen_sources, bc_gen_custom_backend, bc_contrib_sources, bc_gen_custom_contrib],
     kwargs: llvm_irlink_kw,
   )
 

--- a/meson.build
+++ b/meson.build
@@ -814,6 +814,50 @@ if add_languages('cpp', required: llvmopt, native: false)
     # Some distros put LLVM and clang in different paths, so fallback to
     # find via PATH, too.
     clang = find_program(llvm_binpath / 'clang', 'clang', required: true)
+    llvm_lto = find_program(llvm_binpath / 'llvm-lto', required: true)
+    irlink = find_program('src/tools/irlink', native: true)
+
+    # Define a few bits and pieces used here and elsewhere to generate bitcode
+
+    llvm_irgen_args = [
+      '-c', '-o', '@OUTPUT@', '@INPUT@',
+      '-flto=thin', '-emit-llvm',
+      '-MD', '-MQ', '@OUTPUT@', '-MF', '@DEPFILE@',
+      '-O2',
+      '-Wno-ignored-attributes',
+      '-Wno-empty-body',
+    ]
+
+    if ccache.found()
+      llvm_irgen_command = ccache
+      llvm_irgen_args = [clang.path()] + llvm_irgen_args
+    else
+      llvm_irgen_command = clang
+    endif
+
+    llvm_irlink_kw = {
+      'command': [
+        irlink,
+        '--name', 'postgres',
+        '--lto', llvm_lto,
+        '--outdir', '@OUTPUT0@',
+        '--privdir', '@PRIVATE_DIR@',
+        '@INPUT@',
+      ],
+      'install': true,
+      'install_dir': dir_lib_pkg,
+    }
+
+    # XXX: Need to determine proper version of the function cflags for clang
+    bitcode_cflags = ['-fno-strict-aliasing', '-fwrapv']
+    bitcode_cflags += get_option('c_args')
+    bitcode_cflags += cppflags
+
+    # XXX: Worth improving on the logic to find directories here
+    bitcode_cflags += '-I@BUILD_ROOT@/src/include'
+    bitcode_cflags += '-I@BUILD_ROOT@/src/backend/utils/misc'
+    bitcode_cflags += '-I@SOURCE_ROOT@/src/include'
+
   endif
 elif llvmopt.auto()
   message('llvm requires a C++ compiler')
@@ -3061,6 +3105,12 @@ generated_sources = []
 # elements are [dir, [files]]
 generated_sources_ac = {}
 
+# contrib source files used to generate bitcode (--with-llvm)
+llvm_contrib_sources = []
+
+# bitcode files generated from generated source files
+bc_generated_sources = []
+bc_gen_custom = []
 
 # First visit src/include - all targets creating headers are defined
 # within. That makes it easy to add the necessary dependencies for the
@@ -3272,6 +3322,59 @@ above, or by running configure and then make maintainer-clean.
   error(errmsg_nonclean_base.format(errmsg_cleanup))
 endif
 
+
+###############################################################
+# emit LLVM bitcode of backend/contrib code for JIT inlining
+###############################################################
+
+if llvm.found()
+  # custom_target() insists on targeting files into the current
+  # directory. But we have files with the same name in different
+  # subdirectories.  generators() don't have that problem, but their results
+  # are not installable. The irlink command copies the files for us.
+  #
+  # generators don't accept CustomTargetIndex as input or 'depends', nor do
+  # they like targets with more than one output. However, a custom target
+  # accepts them as input without a problem. So we have the below transitive
+  # target :(
+
+  transitive_depend_target = custom_target('stamp',
+    input: generated_headers + generated_backend_headers + generated_backend_sources,
+    output: 'stamp',
+    command: ['touch', '@OUTPUT@'],
+    install: false)
+
+  llvm_gen = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags,
+    depends: [transitive_depend_target] + contrib_targets,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_backend_sources = llvm_gen.process(backend_sources,
+    preserve_path_from: meson.current_source_dir())
+
+  # need to convert generated filenames from relative to absolute paths.
+  # otherwise the generator will not find the files as it uses the current working
+  # directory as base for the filenames.
+  generated_filenames = []
+  foreach gen: bc_generated_sources
+    generated_filenames += gen.full_path()
+  endforeach
+
+  bc_gen_sources = llvm_gen.process(generated_filenames)
+
+  # bc_contrib_sources = llvm_gen.process(llvm_contrib_sources)
+
+  postgres_llvm = custom_target('bitcode',
+    output: ['bitcode'],
+    # input: [bc_backend_sources, bc_generated_sources, bc_contrib_sources],
+    input: [bc_backend_sources, bc_gen_sources, bc_gen_custom],
+    kwargs: llvm_irlink_kw,
+  )
+
+  backend_targets += postgres_llvm
+endif
 
 
 ###############################################################

--- a/src/backend/bootstrap/meson.build
+++ b/src/backend/bootstrap/meson.build
@@ -45,5 +45,5 @@ if llvm.found()
     output: '@PLAINNAME@.bc',
   )
 
-  bc_gen_custom += llvm_gen_bootparser.process(bc_bootparse_sources)
+  bc_gen_custom_backend += llvm_gen_bootparser.process(bc_bootparse_sources)
 endif

--- a/src/backend/bootstrap/meson.build
+++ b/src/backend/bootstrap/meson.build
@@ -5,6 +5,7 @@ backend_sources += files(
 
 # see ../parser/meson.build
 boot_parser_sources = []
+bc_bootparse_sources = []
 
 bootscanner = custom_target('bootscanner',
   input: 'bootscanner.l',
@@ -13,6 +14,7 @@ bootscanner = custom_target('bootscanner',
 )
 generated_sources += bootscanner
 boot_parser_sources += bootscanner
+bc_bootparse_sources += bootscanner
 
 bootparse = custom_target('bootparse',
   input: 'bootparse.y',
@@ -20,6 +22,7 @@ bootparse = custom_target('bootparse',
 )
 generated_sources += bootparse.to_list()
 boot_parser_sources += bootparse
+bc_bootparse_sources += bootparse[0]
 
 boot_parser = static_library('boot_parser',
   boot_parser_sources,
@@ -28,3 +31,19 @@ boot_parser = static_library('boot_parser',
   kwargs: internal_lib_args,
 )
 backend_link_with += boot_parser
+
+if llvm.found()
+  llvm_bootparse_cflags = [
+    '-I@BUILD_ROOT@/src/backend/bootstrap',
+    '-I@SOURCE_ROOT@/src/backend/bootstrap',
+  ]
+
+  llvm_gen_bootparser = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + llvm_bootparse_cflags,
+    depends: boot_parser,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom += llvm_gen_bootparser.process(bc_bootparse_sources)
+endif

--- a/src/backend/jit/llvm/meson.build
+++ b/src/backend/jit/llvm/meson.build
@@ -39,37 +39,6 @@ llvmjit = shared_module('llvmjit',
 
 backend_targets += llvmjit
 
-
-# Define a few bits and pieces used here and elsewhere to generate bitcode
-
-llvm_irgen_args = [
-  '-c', '-o', '@OUTPUT@', '@INPUT@',
-  '-flto=thin', '-emit-llvm',
-  '-MD', '-MQ', '@OUTPUT@', '-MF', '@DEPFILE@',
-  '-O2',
-  '-Wno-ignored-attributes',
-  '-Wno-empty-body',
-]
-
-if ccache.found()
-  llvm_irgen_command = ccache
-  llvm_irgen_args = [clang.path()] + llvm_irgen_args
-else
-  llvm_irgen_command = clang
-endif
-
-
-# XXX: Need to determine proper version of the function cflags for clang
-bitcode_cflags = ['-fno-strict-aliasing', '-fwrapv']
-bitcode_cflags += get_option('c_args')
-bitcode_cflags += cppflags
-
-# XXX: Worth improving on the logic to find directories here
-bitcode_cflags += '-I@BUILD_ROOT@/src/include'
-bitcode_cflags += '-I@BUILD_ROOT@/src/backend/utils/misc'
-bitcode_cflags += '-I@SOURCE_ROOT@/src/include'
-
-
 # Note this is intentionally not installed to bitcodedir, as it's not for
 # inlining
 llvmjit_types = custom_target('llvmjit_types.bc',
@@ -82,3 +51,11 @@ llvmjit_types = custom_target('llvmjit_types.bc',
   depfile: '@BASENAME@.c.bc.d',
 )
 backend_targets += llvmjit_types
+
+# Figure out -I's needed to build all postgres code, including all its
+# dependencies
+pkg_config = find_program(['pkg-config', 'pkgconf'], required: true)
+r = run_command(pkg_config,
+  ['--cflags-only-I', meson.build_root() / 'meson-uninstalled/postgresql-extension-uninstalled.pc'],
+  check: true)
+bitcode_cflags += r.stdout().split()

--- a/src/backend/meson.build
+++ b/src/backend/meson.build
@@ -186,6 +186,100 @@ pg_test_mod_args = pg_mod_args + {
   'install': false
 }
 
+###############################################################
+# Define a .pc file that can be used to build server extensions
+###############################################################
+
+pg_ext_vars = []
+pg_ext_vars_inst = []
+pg_ext_vars_uninst = []
+
+pg_ext_cflags = pg_mod_c_args
+pg_ext_libs = [backend_mod_code, thread_dep, ldflags, ldflags_mod]
+pg_ext_subdirs = ['']
+
+# Compute directories to add include directories to the .pc files for.
+# This is a bit more complicated due to port/win32 etc.
+i = 0
+foreach incdir : postgres_inc_d
+  if incdir.startswith('src/include')
+    subincdir = dir_include_pkg_rel / 'server' / incdir.split('src/include/').get(1, '')
+  else
+    subincdir = ''
+  endif
+  pg_ext_subdirs += subincdir
+
+  # Add directories in source / build dir containing headers to cflags for the
+  # -uninstalled.pc
+  pg_ext_vars_uninst += [
+    'build_inc@0@=-I${prefix}/@1@'.format(i, incdir),
+    'src_inc@0@=-I${srcdir}/@1@'.format(i, incdir),
+  ]
+  pg_ext_cflags += [
+    '${build_inc@0@}'.format(i),
+    '${src_inc@0@}'.format(i)
+  ]
+
+  i += 1
+endforeach
+
+
+# Extension modules should likely also use -fwrapv etc. But it it's a bit odd
+# to expose it to a .pc file?
+pg_ext_cflags += cflags
+
+# Directories for extensions to install into
+# XXX: more needed
+pg_ext_vars += 'pkglibdir=${prefix}/@0@'.format(dir_lib_pkg)
+pg_ext_vars += 'dir_mod=${pkglibdir}'
+pg_ext_vars += 'dir_data=${prefix}/@0@'.format(dir_data_extension)
+# referenced on some platforms, via mod_link_with_dir
+pg_ext_vars += 'bindir=${prefix}/@0@'.format(dir_bin)
+
+# XXX: Define variables making it easy to define tests, too
+
+# Some platforms need linker flags to link with binary, they are the same
+# between building with meson and .pc file, except that we have have to
+# reference a variable to make it work for both normal and -uninstalled .pc
+# files.
+if mod_link_args_fmt.length() != 0
+  assert(link_with_inst != '')
+  assert(link_with_uninst != '')
+
+  pg_ext_vars_inst += 'mod_link_with=@0@'.format(link_with_inst)
+  pg_ext_vars_uninst += 'mod_link_with=@0@'.format(link_with_uninst)
+
+  foreach el : mod_link_args_fmt
+    pg_ext_libs += el.format('${mod_link_with}')
+  endforeach
+endif
+
+# main .pc to build extensions
+pkgconfig.generate(
+  name: 'postgresql-extension',
+  description: 'PostgreSQL Extension Support',
+  url: pg_url,
+
+  subdirs: pg_ext_subdirs,
+  libraries: pg_ext_libs,
+  extra_cflags: pg_ext_cflags,
+
+  variables: pg_ext_vars + pg_ext_vars_inst,
+  uninstalled_variables: pg_ext_vars + pg_ext_vars_uninst,
+)
+
+# a .pc depending on the above, but with all our warnings enabled
+pkgconfig.generate(
+  name: 'postgresql-extension-warnings',
+  description: 'PostgreSQL Extension Support - Compiler Warnings',
+  requires: 'postgresql-extension',
+  url: pg_url,
+  extra_cflags: cflags_warn,
+
+  variables: pg_ext_vars + pg_ext_vars_inst,
+  uninstalled_variables: pg_ext_vars + pg_ext_vars_uninst,
+)
+
 
 
 # Shared modules that, on some system, link against the server binary. Only

--- a/src/backend/nodes/meson.build
+++ b/src/backend/nodes/meson.build
@@ -44,6 +44,6 @@ if llvm.found()
     output: '@PLAINNAME@.bc',
   )
 
-  bc_gen_custom += llvm_gen_nodefunc.process(nodefunc_sources,
+  bc_gen_custom_backend += llvm_gen_nodefunc.process(nodefunc_sources,
     preserve_path_from: meson.current_source_dir())
 endif

--- a/src/backend/nodes/meson.build
+++ b/src/backend/nodes/meson.build
@@ -30,3 +30,20 @@ nodefuncs = static_library('nodefuncs',
   kwargs: internal_lib_args,
 )
 backend_link_with += nodefuncs
+
+if llvm.found()
+  llvm_nodefuncs_cflags = [
+    '-I@SOURCE_ROOT@/src/include/nodes',
+    '-I@BUILD_ROOT@/src/include/nodes',
+  ]
+
+  llvm_gen_nodefunc = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + llvm_nodefuncs_cflags,
+    depends: nodefuncs,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom += llvm_gen_nodefunc.process(nodefunc_sources,
+    preserve_path_from: meson.current_source_dir())
+endif

--- a/src/backend/parser/meson.build
+++ b/src/backend/parser/meson.build
@@ -65,5 +65,5 @@ if llvm.found()
     output: '@PLAINNAME@.bc',
   )
 
-  bc_gen_custom += llvm_gen_parser.process(bc_parser_sources)
+  bc_gen_custom_backend += llvm_gen_parser.process(bc_parser_sources)
 endif

--- a/src/backend/parser/meson.build
+++ b/src/backend/parser/meson.build
@@ -34,6 +34,7 @@ backend_scanner = custom_target('scan',
 )
 generated_sources += backend_scanner
 parser_sources += backend_scanner
+bc_parser_sources = parser_sources
 
 backend_parser = custom_target('gram',
   input: 'gram.y',
@@ -41,6 +42,7 @@ backend_parser = custom_target('gram',
 )
 generated_sources += backend_parser.to_list()
 parser_sources += backend_parser
+bc_parser_sources += backend_parser[0]
 
 parser = static_library('parser',
   parser_sources,
@@ -49,3 +51,19 @@ parser = static_library('parser',
   kwargs: internal_lib_args,
 )
 backend_link_with += parser
+
+if llvm.found()
+  llvm_parser_cflags = [
+    '-I@BUILD_ROOT@/src/backend/parser',
+    '-I@SOURCE_ROOT@/src/backend/parser',
+  ]
+
+  llvm_gen_parser = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + llvm_parser_cflags,
+    depends: parser,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom += llvm_gen_parser.process(bc_parser_sources)
+endif

--- a/src/backend/replication/meson.build
+++ b/src/backend/replication/meson.build
@@ -67,7 +67,7 @@ if llvm.found()
     output: '@PLAINNAME@.bc',
   )
 
-  bc_gen_custom += llvm_gen_repl.process(bc_repl_sources)
+  bc_gen_custom_backend += llvm_gen_repl.process(bc_repl_sources)
 endif
 
 subdir('logical')

--- a/src/backend/replication/meson.build
+++ b/src/backend/replication/meson.build
@@ -19,6 +19,7 @@ repl_scanner = custom_target('repl_scanner',
 )
 generated_sources += repl_scanner
 repl_parser_sources += repl_scanner
+bc_repl_sources = repl_parser_sources
 
 repl_gram = custom_target('repl_gram',
   input: 'repl_gram.y',
@@ -26,6 +27,7 @@ repl_gram = custom_target('repl_gram',
 )
 generated_sources += repl_gram.to_list()
 repl_parser_sources += repl_gram
+bc_repl_sources += repl_gram[0]
 
 syncrep_scanner = custom_target('syncrep_scanner',
   input: 'syncrep_scanner.l',
@@ -34,6 +36,7 @@ syncrep_scanner = custom_target('syncrep_scanner',
 )
 generated_sources += syncrep_scanner
 repl_parser_sources += syncrep_scanner
+bc_repl_sources += syncrep_scanner
 
 syncrep_gram = custom_target('syncrep_gram',
   input: 'syncrep_gram.y',
@@ -41,6 +44,7 @@ syncrep_gram = custom_target('syncrep_gram',
 )
 generated_sources += syncrep_gram.to_list()
 repl_parser_sources += syncrep_gram
+bc_repl_sources += syncrep_gram[0]
 
 repl_parser = static_library('repl_parser',
   repl_parser_sources,
@@ -49,5 +53,21 @@ repl_parser = static_library('repl_parser',
   kwargs: internal_lib_args,
 )
 backend_link_with += repl_parser
+
+if llvm.found()
+  llvm_gen_repl_cflags = [
+  '-I@BUILD_ROOT@/src/backend/replication',
+  '-I@SOURCE_ROOT@/src/backend/replication',
+  ]
+
+  llvm_gen_repl = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + llvm_gen_repl_cflags,
+    depends: repl_parser,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom += llvm_gen_repl.process(bc_repl_sources)
+endif
 
 subdir('logical')

--- a/src/backend/utils/activity/meson.build
+++ b/src/backend/utils/activity/meson.build
@@ -49,5 +49,5 @@ if llvm.found()
     output: '@PLAINNAME@.bc',
   )
 
-  bc_gen_custom += llvm_wait_event.process(waitevent_sources)
+  bc_gen_custom_backend += llvm_wait_event.process(waitevent_sources)
 endif

--- a/src/backend/utils/activity/meson.build
+++ b/src/backend/utils/activity/meson.build
@@ -35,3 +35,19 @@ wait_event = static_library('wait_event_names',
 )
 
 backend_link_with += wait_event
+
+if llvm.found()
+  llvm_wait_event_cflags = [
+    '-I@BUILD_ROOT@/src/include/utils',
+    '-I@SOURCE_ROOT@/src/include/utils',
+  ]
+
+  llvm_wait_event = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + llvm_wait_event_cflags,
+    depends: wait_event,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom += llvm_wait_event.process(waitevent_sources)
+endif

--- a/src/backend/utils/adt/meson.build
+++ b/src/backend/utils/adt/meson.build
@@ -151,7 +151,7 @@ if llvm.found()
     output: '@PLAINNAME@.bc',
   )
 
-  bc_gen_custom += llvm_jsonpath.process(bc_jsonpath_sources)
+  bc_gen_custom_backend += llvm_jsonpath.process(bc_jsonpath_sources)
 endif
 
 #generated_backend_sources += jsonpath_gram.to_list()

--- a/src/backend/utils/adt/meson.build
+++ b/src/backend/utils/adt/meson.build
@@ -113,6 +113,7 @@ backend_sources += files(
   'xml.c',
 )
 
+bc_jsonpath_sources = []
 
 jsonpath_scan = custom_target('jsonpath_scan',
   input: 'jsonpath_scan.l',
@@ -120,12 +121,14 @@ jsonpath_scan = custom_target('jsonpath_scan',
   command: [flex_cmd, '--no-backup', '--', '-CF', '-p', '-p'],
 )
 generated_sources += jsonpath_scan
+bc_jsonpath_sources += jsonpath_scan
 
 jsonpath_gram = custom_target('jsonpath_parse',
   input: 'jsonpath_gram.y',
   kwargs: bison_kw,
 )
 generated_sources += jsonpath_gram.to_list()
+bc_jsonpath_sources += jsonpath_gram[0]
 
 # so we don't need to add . as an include dir for the whole backend
 backend_link_with += static_library('jsonpath',
@@ -134,5 +137,21 @@ backend_link_with += static_library('jsonpath',
   include_directories: include_directories('.'),
   kwargs: internal_lib_args,
 )
+
+if llvm.found()
+  llvm_jsonpath_cflags = [
+    '-I@BUILD_ROOT@/src/backend/utils/adt',
+    '-I@SOURCE_ROOT@/src/backend/utils/adt',
+  ]
+
+  llvm_jsonpath = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + llvm_jsonpath_cflags,
+    depends: [jsonpath_scan, jsonpath_gram],
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom += llvm_jsonpath.process(bc_jsonpath_sources)
+endif
 
 #generated_backend_sources += jsonpath_gram.to_list()

--- a/src/backend/utils/misc/meson.build
+++ b/src/backend/utils/misc/meson.build
@@ -46,7 +46,7 @@ if llvm.found()
     output: '@PLAINNAME@.bc',
   )
 
-  bc_gen_custom += llvm_guc_file.process(guc_scan)
+  bc_gen_custom_backend += llvm_guc_file.process(guc_scan)
 endif
 
 install_data('postgresql.conf.sample',

--- a/src/backend/utils/misc/meson.build
+++ b/src/backend/utils/misc/meson.build
@@ -34,6 +34,21 @@ backend_link_with += static_library('guc-file',
   kwargs: internal_lib_args,
 )
 
+if llvm.found()
+  llvm_guc_file_cflags = [
+    '-I@SOURCE_ROOT@/src/backend/utils/misc',
+  ]
+
+  llvm_guc_file = generator(llvm_irgen_command,
+    arguments: llvm_irgen_args + bitcode_cflags + llvm_guc_file_cflags,
+    depends: guc_scan,
+    depfile: '@BASENAME@.c.bc.d',
+    output: '@PLAINNAME@.bc',
+  )
+
+  bc_gen_custom += llvm_guc_file.process(guc_scan)
+endif
+
 install_data('postgresql.conf.sample',
   install_dir: dir_data,
 )

--- a/src/include/utils/meson.build
+++ b/src/include/utils/meson.build
@@ -69,6 +69,7 @@ fmgrtab_target = custom_target('fmgrtab',
 
 generated_backend_headers += fmgrtab_target[0]
 generated_backend_headers += fmgrtab_target[1]
+bc_generated_sources += fmgrtab_target[2]
 
 # autoconf generates the file there, ensure we get a conflict
 generated_sources_ac += {

--- a/src/tools/irlink
+++ b/src/tools/irlink
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import sys
+import argparse
+
+parser = argparse.ArgumentParser(
+    description='generate PostgreSQL JIT IR module')
+
+parser.add_argument('--name', type=str, required=True)
+parser.add_argument('--lto', type=str, required=True)
+parser.add_argument('--privdir', type=str, required=True)
+parser.add_argument('--outdir', type=str, required=True)
+parser.add_argument('INPUT', type=str, nargs='+')
+
+args = parser.parse_args()
+
+outdir = os.path.realpath(args.outdir)
+privdir = os.path.realpath(args.privdir)
+
+index = '{0}/{1}.index.bc'.format(outdir, args.name)
+destdir = '{0}/{1}'.format(outdir, args.name)
+
+# Remove old contents if exist
+if os.path.exists(destdir):
+    shutil.rmtree(destdir)
+
+shutil.copytree(privdir, destdir)
+
+# Change working directory for irlink to link correctly
+os.chdir(args.outdir)
+
+file_names = []
+for input in args.INPUT:
+    file_names += [args.name + input.replace(args.privdir, '')]
+
+command = [args.lto, '-thinlto', '-thinlto-action=thinlink',
+           '-o', index] + file_names
+res = subprocess.run(command)
+
+exit(res.returncode)


### PR DESCRIPTION
This PR adds support for generating llvm bitcode files when building PostgreSQL with meson (`-Dllvm=enabled`).

It handles both static C source files and generated source files as well (flex, bison, etc).