### PR TITLE
Add pg_get_database_ddl() function to reconstruct CREATE DATABASE statements.

### DIFF
--- a/doc/src/sgml/func/func-info.sgml
+++ b/doc/src/sgml/func/func-info.sgml
@@ -3797,4 +3797,47 @@ acl      | {postgres=arwdDxtm/postgres,foo=r/postgres}
 
   </sect2>
 
+  <sect2 id="functions-get-object-ddl">
+   <title>Get Object DDL Functions</title>
+
+   <para>
+    The functions shown in <xref linkend="functions-get-object-ddl-table"/>
+    return the DDL statements for various database objects.
+    (This is a decompiled reconstruction, not the original text
+    of the command.)
+   </para>
+
+   <table id="functions-get-object-ddl-table">
+    <title>Get Object DDL Functions</title>
+    <tgroup cols="1">
+     <thead>
+      <row>
+       <entry role="func_table_entry"><para role="func_signature">
+        Function
+       </para>
+       <para>
+        Description
+       </para></entry>
+      </row>
+     </thead>
+
+     <tbody>
+      <row>
+       <entry role="func_table_entry"><para role="func_signature">
+        <indexterm>
+         <primary>pg_get_database_ddl</primary>
+        </indexterm>
+        <function>pg_get_database_ddl</function> ( <parameter>database_name</parameter> <type>text</type>, <parameter>pretty_formatted</parameter> <type>boolean</type> )
+        <returnvalue>text</returnvalue>
+       </para>
+       <para>
+        Reconstructs the CREATE DATABASE statement from the system catalogs for a given database name.
+        The result is a comprehensive <command>CREATE DATABASE</command> statement.
+       </para></entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+
+  </sect2>
   </sect1>

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -4021,6 +4021,9 @@
   proname => 'pg_get_function_sqlbody', provolatile => 's',
   prorettype => 'text', proargtypes => 'oid',
   prosrc => 'pg_get_function_sqlbody' },
+{ oid => '9492', descr => 'get CREATE statement for database',
+  proname => 'pg_get_database_ddl', prorettype => 'text',
+  proargtypes => 'name bool', prosrc => 'pg_get_database_ddl' },
 
 { oid => '1686', descr => 'list of SQL keywords',
   proname => 'pg_get_keywords', procost => '10', prorows => '500',

--- a/src/test/regress/expected/database_ddl.out
+++ b/src/test/regress/expected/database_ddl.out
@@ -1,0 +1,94 @@
+-- Without Pretty formatted
+-- Create a specific role to test
+CREATE ROLE test_database_ddl_role WITH SUPERUSER;
+CREATE DATABASE "test_get_database_ddl"
+    OWNER test_database_ddl_role ENCODING utf8 LC_COLLATE "C" LC_CTYPE "C" TEMPLATE template0;
+SELECT pg_get_database_ddl('test_get_database_ddl', false);
+                                                                                                    pg_get_database_ddl                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  CREATE DATABASE test_get_database_ddl WITH OWNER = test_database_ddl_role ENCODING = "UTF8" LC_COLLATE = "C" LC_CTYPE = "C" LOCALE_PROVIDER = 'libc' TABLESPACE = pg_default ALLOW_CONNECTIONS = 1 CONNECTION LIMIT = -1;
+(1 row)
+
+DROP DATABASE "test_get_database_ddl";
+-- Test LOCAL_PROVIDER and BUILTIN_LOCALE for builtin type
+CREATE DATABASE "test_get_database_ddl_builtin"
+    OWNER test_database_ddl_role TEMPLATE template0 ENCODING 'UTF8'
+    BUILTIN_LOCALE 'C.UTF-8' LOCALE_PROVIDER 'builtin';
+SELECT pg_get_database_ddl('test_get_database_ddl_builtin', false);
+                                                                                                                                     pg_get_database_ddl                                                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  CREATE DATABASE test_get_database_ddl_builtin WITH OWNER = test_database_ddl_role ENCODING = "UTF8" LC_COLLATE = "C" LC_CTYPE = "UTF-8" BUILTIN_LOCALE = "C.UTF-8" COLLATION_VERSION = "1" LOCALE_PROVIDER = 'builtin' TABLESPACE = pg_default ALLOW_CONNECTIONS = 1 CONNECTION LIMIT = -1;
+(1 row)
+
+DROP DATABASE "test_get_database_ddl_builtin";
+-- Test ALLOW_CONNECTION and CONNECTION_LIMIT
+CREATE DATABASE "test_get_database_ddl_conn"
+    OWNER test_database_ddl_role TEMPLATE template0 ENCODING 'UTF8'
+    ALLOW_CONNECTIONS 0 CONNECTION LIMIT 50;
+SELECT pg_get_database_ddl('test_get_database_ddl_conn', false);
+                                                                                              pg_get_database_ddl                                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  CREATE DATABASE test_get_database_ddl_conn WITH OWNER = test_database_ddl_role ENCODING = "UTF8" LC_COLLATE = "C" LC_CTYPE = "UTF-8" LOCALE_PROVIDER = 'libc' TABLESPACE = pg_default CONNECTION LIMIT = 50;
+(1 row)
+
+DROP DATABASE "test_get_database_ddl_conn";
+-- With Pretty formatted
+\pset format unaligned
+CREATE DATABASE "test_get_database_ddl"
+    OWNER test_database_ddl_role ENCODING utf8 LC_COLLATE "C" LC_CTYPE "C" TEMPLATE template0;
+SELECT pg_get_database_ddl('test_get_database_ddl', true);
+pg_get_database_ddl
+CREATE DATABASE test_get_database_ddl
+	WITH
+	OWNER = test_database_ddl_role
+	ENCODING = "UTF8"
+	LC_COLLATE = "C"
+	LC_CTYPE = "C"
+	LOCALE_PROVIDER = 'libc'
+	TABLESPACE = pg_default
+	ALLOW_CONNECTIONS = 1
+	CONNECTION LIMIT = -1
+;
+(1 row)
+DROP DATABASE "test_get_database_ddl";
+-- Test LOCAL_PROVIDER and BUILTIN_LOCALE for builtin type
+CREATE DATABASE "test_get_database_ddl_builtin"
+    OWNER test_database_ddl_role TEMPLATE template0 ENCODING 'UTF8'
+    BUILTIN_LOCALE 'C.UTF-8' LOCALE_PROVIDER 'builtin';
+SELECT pg_get_database_ddl('test_get_database_ddl_builtin', true);
+pg_get_database_ddl
+CREATE DATABASE test_get_database_ddl_builtin
+	WITH
+	OWNER = test_database_ddl_role
+	ENCODING = "UTF8"
+	LC_COLLATE = "C"
+	LC_CTYPE = "UTF-8"
+	BUILTIN_LOCALE = "C.UTF-8"
+	COLLATION_VERSION = "1"
+	LOCALE_PROVIDER = 'builtin'
+	TABLESPACE = pg_default
+	ALLOW_CONNECTIONS = 1
+	CONNECTION LIMIT = -1
+;
+(1 row)
+DROP DATABASE "test_get_database_ddl_builtin";
+-- Test ALLOW_CONNECTION and CONNECTION_LIMIT
+CREATE DATABASE "test_get_database_ddl_conn"
+    OWNER test_database_ddl_role TEMPLATE template0 ENCODING 'UTF8'
+    ALLOW_CONNECTIONS 0 CONNECTION LIMIT 50;
+SELECT pg_get_database_ddl('test_get_database_ddl_conn', true);
+pg_get_database_ddl
+CREATE DATABASE test_get_database_ddl_conn
+	WITH
+	OWNER = test_database_ddl_role
+	ENCODING = "UTF8"
+	LC_COLLATE = "C"
+	LC_CTYPE = "UTF-8"
+	LOCALE_PROVIDER = 'libc'
+	TABLESPACE = pg_default
+	CONNECTION LIMIT = 50
+;
+(1 row)
+DROP DATABASE "test_get_database_ddl_conn";
+-- Clean up
+DROP ROLE test_database_ddl_role;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -137,6 +137,13 @@ test: event_trigger_login
 # this test also uses event triggers, so likewise run it by itself
 test: fast_default
 
+# ----------
+# Another group of parallel tests
+#
+# This group tests all of the object DDL reconstruction.
+# ----------
+test: database_ddl
+
 # run tablespace test at the end because it drops the tablespace created during
 # setup that other tests may use.
 test: tablespace

--- a/src/test/regress/sql/database_ddl.sql
+++ b/src/test/regress/sql/database_ddl.sql
@@ -1,0 +1,52 @@
+-- Without Pretty formatted
+
+-- Create a specific role to test
+CREATE ROLE test_database_ddl_role WITH SUPERUSER;
+CREATE DATABASE "test_get_database_ddl"
+    OWNER test_database_ddl_role ENCODING utf8 LC_COLLATE "C" LC_CTYPE "C" TEMPLATE template0;
+SELECT pg_get_database_ddl('test_get_database_ddl', false);
+DROP DATABASE "test_get_database_ddl";
+
+
+-- Test LOCAL_PROVIDER and BUILTIN_LOCALE for builtin type
+CREATE DATABASE "test_get_database_ddl_builtin"
+    OWNER test_database_ddl_role TEMPLATE template0 ENCODING 'UTF8'
+    BUILTIN_LOCALE 'C.UTF-8' LOCALE_PROVIDER 'builtin';
+SELECT pg_get_database_ddl('test_get_database_ddl_builtin', false);
+DROP DATABASE "test_get_database_ddl_builtin";
+
+
+-- Test ALLOW_CONNECTION and CONNECTION_LIMIT
+CREATE DATABASE "test_get_database_ddl_conn"
+    OWNER test_database_ddl_role TEMPLATE template0 ENCODING 'UTF8'
+    ALLOW_CONNECTIONS 0 CONNECTION LIMIT 50;
+SELECT pg_get_database_ddl('test_get_database_ddl_conn', false);
+DROP DATABASE "test_get_database_ddl_conn";
+
+
+-- With Pretty formatted
+\pset format unaligned
+CREATE DATABASE "test_get_database_ddl"
+    OWNER test_database_ddl_role ENCODING utf8 LC_COLLATE "C" LC_CTYPE "C" TEMPLATE template0;
+SELECT pg_get_database_ddl('test_get_database_ddl', true);
+DROP DATABASE "test_get_database_ddl";
+
+
+-- Test LOCAL_PROVIDER and BUILTIN_LOCALE for builtin type
+CREATE DATABASE "test_get_database_ddl_builtin"
+    OWNER test_database_ddl_role TEMPLATE template0 ENCODING 'UTF8'
+    BUILTIN_LOCALE 'C.UTF-8' LOCALE_PROVIDER 'builtin';
+SELECT pg_get_database_ddl('test_get_database_ddl_builtin', true);
+DROP DATABASE "test_get_database_ddl_builtin";
+
+
+-- Test ALLOW_CONNECTION and CONNECTION_LIMIT
+CREATE DATABASE "test_get_database_ddl_conn"
+    OWNER test_database_ddl_role TEMPLATE template0 ENCODING 'UTF8'
+    ALLOW_CONNECTIONS 0 CONNECTION LIMIT 50;
+SELECT pg_get_database_ddl('test_get_database_ddl_conn', true);
+DROP DATABASE "test_get_database_ddl_conn";
+
+
+-- Clean up
+DROP ROLE test_database_ddl_role;


### PR DESCRIPTION
This adds a new system function, pg_get_database_ddl(name database_name, bool pretty),
which reconstructs the CREATE DATABASE statement for a given database name.

Usage:
  SELECT pg_get_database_ddl('postgres', false); // non pretty formatted DDL
  SELECT pg_get_database_ddl('postgres', true); // pretty formatted DDL

Reference: PG-150
Author: Akshay Joshi <akshay.joshi@enterprisedb.com>
Author: Mark Wong <markwkm@gmail.com>
Reviewed-by: Álvaro Herrera <alvherre@alvh.no-ip.org>