### PR TITLE
Provide a function to emit DDL for CREATE EVENT TRIGGER

### DIFF
--- a/doc/src/sgml/func/func-info.sgml
+++ b/doc/src/sgml/func/func-info.sgml
@@ -3797,4 +3797,56 @@ acl      | {postgres=arwdDxtm/postgres,foo=r/postgres}
 
   </sect2>
 
+  <sect2 id="functions-info-retail">
+   <title>DDL Retail Functions</title>
+
+   <para>
+    <xref linkend="functions-info-retail-table"/> lists functions that
+    extract information about ....
+   </para>
+
+   <table id="functions-info-retail-table">
+    <title>DDL Retail Functions</title>
+    <tgroup cols="1">
+     <thead>
+      <row>
+       <entry role="func_table_entry"><para role="func_signature">
+        Function
+       </para>
+       <para>
+        Description
+       </para></entry>
+      </row>
+     </thead>
+
+     <tbody>
+      <row>
+       <entry role="func_table_entry"><para role="func_signature">
+        <indexterm>
+         <primary>pg_get_event_trigger_ddl</primary>
+        </indexterm>
+        <function>pg_get_event_trigger_ddl</function>
+        (<parameter>event trigger name</parameter> <type>name</type>)
+        <returnvalue>text</returnvalue>
+       </para>
+       <para>
+        Reconstructs the underlying DDL statement for a specified event trigger.
+        It returns the complete CREATE EVENT TRIGGER statement. For example,
+        <programlisting>
+        SELECT pg_get_event_trigger_ddl('example_trigger');
+        </programlisting> will return the full CREATE EVENT TRIGGER statement
+        <programlisting>
+         CREATE EVENT TRIGGER example_trigger
+           ON forbid_rewrites
+           WHEN TAG IN ('ALTER TABLE','ALTER MATERIALIZED VIEW')
+           EXECUTE FUNCTION public.forbid_table_rewrites();
+        </programlisting>
+       </para></entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+
+  </sect2>
+
   </sect1>

--- a/src/include/catalog/pg_proc.dat
+++ b/src/include/catalog/pg_proc.dat
@@ -8547,6 +8547,9 @@
 { oid => '2730', descr => 'trigger description with pretty-print option',
   proname => 'pg_get_triggerdef', provolatile => 's', prorettype => 'text',
   proargtypes => 'oid bool', prosrc => 'pg_get_triggerdef_ext' },
+{ oid => '9067', descr => 'get CREATE statement for event trigger',
+  proname => 'pg_get_event_trigger_ddl', proisstrict => 'f', 
+  prorettype => 'text', proargtypes => 'name', prosrc => 'pg_get_event_trigger_ddl' },
 
 # asynchronous notifications
 { oid => '3035',

--- a/src/test/regress/expected/event_trigger.out
+++ b/src/test/regress/expected/event_trigger.out
@@ -84,6 +84,18 @@ create event trigger regress_event_trigger2 on ddl_command_start
    execute procedure test_event_trigger();
 -- OK
 comment on event trigger regress_event_trigger is 'test comment';
+-- check DDL output
+SELECT pg_get_event_trigger_ddl('regress_event_trigger2');
+             pg_get_event_trigger_ddl             
+--------------------------------------------------
+ CREATE EVENT TRIGGER ddl_command_start          +
+  ON regress_event_trigger2                      +
+   WHEN TAG IN ('CREATE TABLE','CREATE FUNCTION')+
+   EXECUTE FUNCTION public.test_event_trigger();
+(1 row)
+
+SELECT pg_get_event_trigger_ddl(NULL);
+ERROR:  input cannot be null
 -- drop as non-superuser should fail
 create role regress_evt_user;
 set role regress_evt_user;

--- a/src/test/regress/sql/event_trigger.sql
+++ b/src/test/regress/sql/event_trigger.sql
@@ -85,6 +85,10 @@ create event trigger regress_event_trigger2 on ddl_command_start
 -- OK
 comment on event trigger regress_event_trigger is 'test comment';
 
+-- check DDL output
+SELECT pg_get_event_trigger_ddl('regress_event_trigger2');
+SELECT pg_get_event_trigger_ddl(NULL);
+
 -- drop as non-superuser should fail
 create role regress_evt_user;
 set role regress_evt_user;


### PR DESCRIPTION
This patch implements the pg_get_event_trigger_ddl() function, which emits the DDL for CREATE EVENT TRIGGER.

PG-158

Author: Ian Barwick <barwick@gmail.com>
Co-authored-by: Phil Alger <phil.alger@enterprisedb.com>